### PR TITLE
Update README: fix download links (is.gd -> kutt.it)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ There is a **beta release** (recommended) and a **stable release**. Beta gets ne
 
 You can use either of the following methods to install the app:
 
-- (**easiest**) install [Downloader by AFTVnews](https://www.aftvnews.com/downloader/) on your Android TV, open it and enter `is.gd/stn_beta` or `is.gd/stn_stable`, then read, understand and confirm the security prompts. (<small>You can also enter [**79015**](https://aftv.news/79015) (for beta) or [**28544**](https://aftv.news/28544) (for stable), but this requires an extra step to install the AFTVnews Downloader browser addon if you haven't already.</small>)
+- (**easiest**) install [Downloader by AFTVnews](https://www.aftvnews.com/downloader/) on your Android TV, open it and enter `kutt.it/stn_beta` or `kutt.it/stn_stable`, then read, understand and confirm the security prompts. (<small>You can also enter [**79015**](https://aftv.news/79015) (for beta) or [**28544**](https://aftv.news/28544) (for stable), but this requires an extra step to install the AFTVnews Downloader browser addon if you haven't already.</small>)
 - install a file transfer app on your Android TV, download the APK on your phone or computer and transfer it to your TV (e.g. [_Send Files to TV_](https://sendfilestotv.app/)\*)
 - download the APK onto a USB stick, put the USB stick into your TV and use a file manager app (e.g. [_FX File Explorer_](https://play.google.com/store/apps/details?id=nextapp.fx)\* or [_FileCommander_](https://play.google.com/store/apps/details?id=com.mobisystems.fileman)\*). Android's preinstalled file manager does not work!
 - if you are an advanced user, you can install it using ADB. [guide](https://fossbytes.com/side-load-apps-android-tv/#h-how-to-sideload-apps-on-your-android-tv-using-adb) | [alternative guide](https://www.aftvnews.com/sideload/)
@@ -112,14 +112,14 @@ To enable voice search, an additional app must be installed alongside SmartTubeN
 **On Amazon Fire TV**, to enable voice search support you need to: 
 
 1. uninstall the original YouTube app (no root required on Amazon FireTV stick)
-2. download and install the Amazon Bridge SmartTubeNext app: https://is.gd/stn_bridge_amazon (e.g. via _Downloader for AFTVnews_)
+2. download and install the Amazon Bridge SmartTubeNext app: https://kutt.it/stn_bridge_amazon (e.g. via _Downloader for AFTVnews_)
 
 
 **On all other Android devices**, sadly root is required to enable this:
 
 1. root your device (search for a guide for your specific device)
 2. uninstall the official YouTube app using root (`adb shell pm uninstall com.google.android.youtube.tv`)
-3. download and install the ATV Bridge SmartTubeNext app: https://is.gd/stn_bridge_atv
+3. download and install the ATV Bridge SmartTubeNext app: https://kutt.it/stn_bridge_atv (e.g. via _Downloader for AFTVnews_)
 
 
 ## Donation


### PR DESCRIPTION
As after years of operation, is.gd currently seems to be offline.

The list of free url shorteners that allow custom URLs is quite short, but [kutt.it](https://kutt.it) was the first alternative I could find that works just as well. Personally, I find custom URLs with memorizable words to be a lot easier to work with, than trying to type in some random characters on a TV remote.

Note: unlike most URL shorteners, kutt.it allows URLs to be changed afterwards by the user who created them. If trust (in me) is an issue, you might want to create the links yourself.