### PR TITLE
Delete reference to untranslated language (values-es-rAR)

### DIFF
--- a/common/src/main/res/values/languages.xml
+++ b/common/src/main/res/values/languages.xml
@@ -29,7 +29,6 @@
         <item>Slovenian|sl</item>
         <item>English (New Zealand)|en_NZ</item>
         <item>Español|es</item>
-        <item>Español (Argentina)|es_AR</item>
         <item>Ελληνικά|el_GR</item>
         <item>Português|pt_PT</item>
         <item>Português (Brasileiro)|pt_BR</item>


### PR DESCRIPTION
Personally I see the reference to "values-es-rAR" as irrelevant, since there is no translation. And also because the "Español" translation "values-es" is valid for all Spanish-speaking countries.