### PR TITLE
Update countries.xml

### DIFF
--- a/common/src/main/res/values/countries.xml
+++ b/common/src/main/res/values/countries.xml
@@ -25,17 +25,17 @@
         <item>Hungary|HU</item>
         <item>Nederland|NL</item>
         <item>België|BE</item>
-        <item>België (Nederland)|nl_BE</item>
-        <item>België (France)|fr_BE</item>
-        <item>Norsk|NB</item>
-        <item>Czech|CS</item>
+        <item>België (dutch)|nl_BE</item>
+        <item>België (french)|fr_BE</item>
+        <item>Noreg|NO</item>
+        <item>Czech|CZ</item>
         <item>Italia|IT</item>
         <item>Ελληνικά|GR</item>
         <item>Denmark|DK</item>
         <item>Lietuva|LT</item>
-        <item>Moldova|MO</item>
+        <item>Moldova|MD</item>
         <item>Slovakia|SK</item>
-        <item>Slovenia|SL</item>
+        <item>Slovenia|SI</item>
         <item>Sweden|SE</item>
         <item>Singapore|SG</item>
         <item>New Zealand|NZ</item>
@@ -61,7 +61,7 @@
         <item>China|CN</item>
         <item>Taiwan|TW</item>
         <item>Indonesia|ID</item>
-        <item>Korea|KR</item>
+        <item>South Korea|KR</item>
         <item>Pakistan|PK</item>
         <item>Bolivia|BO</item>
         <item>Chile|CL</item>


### PR DESCRIPTION
fix country codes (Czech, Moldova, Slovenia) and country names (Norway, South Korea).

FYI While I didn't find a list of countries in their native language(s) (e.g. "Україна" instead of "Ukraine", I found the following resources helpful, maybe we can completely integrate them incl. translations:
- https://github.com/stefangabos/world_countries/blob/master/data/countries/_combined/world.csv
- https://github.com/stefangabos/world_countries/blob/master/data/subdivisions/subdivisions.csv (English only)

or if we go completely crazy, there's the Unicode CLDR project. But it involves a lot more parsing and piecing together.

Apparently, Youtube also offers an API https://developers.google.com/youtube/v3/docs/i18nRegions/list

Also, I'm not sure if `nl_BE` and `fr_BE` are actual region codes supported by Youtube, it looks like this is supposed to go into the language code.