### PR TITLE
player controls: make screen off action consistent with sound off action

### DIFF
--- a/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/tv/ui/playback/actions/ScreenOffTimeoutAction.java
+++ b/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/tv/ui/playback/actions/ScreenOffTimeoutAction.java
@@ -10,7 +10,7 @@ public class ScreenOffTimeoutAction extends TwoStateAction {
     public ScreenOffTimeoutAction(Context context) {
         super(context, R.id.action_screen_off_timeout, R.drawable.action_screen_timeout_on);
 
-        String label = context.getString(R.string.player_screen_off_timeout);
+        String label = context.getString(R.string.action_screen_off);
         String[] labels = new String[2];
         // Note, labels denote the action taken when clicked
         labels[INDEX_OFF] = label;


### PR DESCRIPTION
Short press turns screen off and I think action description should reflect that -- in the same way it works for the "sound off" action.