### PR TITLE
feat: add original language option as audio track selection

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/exoplayer/selector/TrackSelectorManager.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/exoplayer/selector/TrackSelectorManager.java
@@ -680,7 +680,9 @@ public class TrackSelectorManager implements TrackSelectorCallback {
             }
         }
 
-        if (resultTracks != null && !resultTracks.isEmpty()) {
+        boolean useOriginalLanguage = PlayerData.ORIGINAL_LANGUAGE.equals(audioLanguage);
+
+        if (!useOriginalLanguage && resultTracks != null && !resultTracks.isEmpty()) {
             return resultTracks.toArray(new MediaTrack[0][]);
         }
 

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/prefs/PlayerData.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/prefs/PlayerData.java
@@ -37,6 +37,7 @@ public class PlayerData extends DataChangeBase implements PlayerEngineConstants,
     public static final int SEEK_PREVIEW_SINGLE = 1;
     public static final int SEEK_PREVIEW_CAROUSEL_SLOW = 2;
     public static final int SEEK_PREVIEW_CAROUSEL_FAST = 3;
+    public static final String ORIGINAL_LANGUAGE = "original_language";
     @SuppressLint("StaticFieldLeak")
     private static PlayerData sInstance;
     private final AppPrefs mPrefs;

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/utils/AppDialogUtil.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/utils/AppDialogUtil.java
@@ -362,6 +362,13 @@ public class AppDialogUtil {
                 },
                 "".equals(playerData.getAudioLanguage())));
 
+        options.add(1, UiOptionItem.from(context.getString(R.string.original_language),
+                optionItem -> {
+                    playerData.setAudioLanguage(PlayerData.ORIGINAL_LANGUAGE);
+                    onSetCallback.run();
+                },
+                PlayerData.ORIGINAL_LANGUAGE.equals(playerData.getAudioLanguage())));
+
         return OptionCategory.from(AUDIO_LANGUAGE_ID, OptionCategory.TYPE_RADIO_LIST, title, options);
     }
 

--- a/common/src/main/res/values-ar/strings.xml
+++ b/common/src/main/res/values-ar/strings.xml
@@ -685,4 +685,5 @@
   <string name="screen_dimming_amount">قيمة تعتيم الشاشة</string>
   <string name="screen_dimming_timeout">مهلة تعتيم الشاشة</string>
   <string name="playlists_rows">عرض قسم قوائم التشغيل كصفوف</string>
+  <string name="original_language">اللغة الأصلية</string>
 </resources>

--- a/common/src/main/res/values-de/strings.xml
+++ b/common/src/main/res/values-de/strings.xml
@@ -687,4 +687,5 @@
     <string name="screen_dimming_amount">Wert für Bildschirm dimmen</string>
     <string name="screen_dimming_timeout">Zeit für Bildschirm dimmen</string>
     <string name="playlists_rows">Wiedergabelisten-Kategorie als Reihen anzeigen</string>
+    <string name="original_language">Originalsprache</string>
 </resources>

--- a/common/src/main/res/values-es/strings.xml
+++ b/common/src/main/res/values-es/strings.xml
@@ -684,4 +684,5 @@
   <string name="video_buffer_size_highest">Más alto</string>
   <string name="unpin_group_from_sidebar">Eliminar el grupo de suscripción</string>
   <string name="playlists_rows">Mostrar la sección de listas de reproducción como filas</string>
+    <string name="original_language">Idioma original</string>
 </resources>

--- a/common/src/main/res/values-fr/strings.xml
+++ b/common/src/main/res/values-fr/strings.xml
@@ -687,4 +687,5 @@
   <string name="not_supported_by_device">L\'appareil ne prend pas en charge cette fonctionnalité</string>
   <string name="hide_shorts_from_search">Masquer les shorts dans les résultats de recherche</string>
   <string name="suggestions">Suggestions</string>
+  <string name="original_language">Langue originale</string>
 </resources>

--- a/common/src/main/res/values-hi/strings.xml
+++ b/common/src/main/res/values-hi/strings.xml
@@ -570,4 +570,5 @@
   <string name="header_shorts">शॉर्ट्स</string>
   <string name="unlock_high_bitrate_formats">उच्च बिटरेट 1080p VP9 प्रारूप अनलॉक करें</string>
   <string name="unlock_high_bitrate_audio_formats">उच्च बिटरेट mp4a प्रारूप अनलॉक करें</string>
+    <string name="original_language">मूल भाषा</string>
 </resources>

--- a/common/src/main/res/values-in/strings.xml
+++ b/common/src/main/res/values-in/strings.xml
@@ -665,4 +665,5 @@
     <string name="screen_dimming_amount">Jumlah peredupan layar</string>
     <string name="screen_dimming_timeout">Batas waktu peredupan layar</string>
     <string name="playlists_rows">Tampilkan bagian Daftar Putar sebagai baris</string>
+    <string name="original_language">Bahasa asli</string>
 </resources>

--- a/common/src/main/res/values-it/strings.xml
+++ b/common/src/main/res/values-it/strings.xml
@@ -687,4 +687,5 @@
     <string name="screen_dimming_amount">Quantità oscuramento schermo</string>
     <string name="screen_dimming_timeout">Timeout oscuramento schermo</string>
     <string name="playlists_rows">Mostra la sezione Playlist come righe</string>
+    <string name="original_language">Lingua originale</string>
 </resources>

--- a/common/src/main/res/values-ja/strings.xml
+++ b/common/src/main/res/values-ja/strings.xml
@@ -684,4 +684,5 @@
     <string name="rename_group">登録チャンネルグループの名前を変更</string>
     <string name="screen_dimming_amount">画面の減光量</string>
     <string name="screen_dimming_timeout">画面減光のタイムアウト</string>
+    <string name="original_language">元の言語</string>
 </resources>

--- a/common/src/main/res/values-ko/strings.xml
+++ b/common/src/main/res/values-ko/strings.xml
@@ -686,4 +686,5 @@
   <string name="playlists_rows">재생목록 섹션을 행으로 표시</string>
   <string name="not_supported_by_device">해당 장치는 이 기능을 지원하지 않음</string>
   <string name="suggestions">제안</string>
+    <string name="original_language">원래 언어</string>
 </resources>

--- a/common/src/main/res/values-nb/strings.xml
+++ b/common/src/main/res/values-nb/strings.xml
@@ -155,4 +155,5 @@
     <string name="move_section_down">Flytt seksjon ned</string>
     <string name="rename_section">Gi nytt navn til seksjon</string>
     <string name="action_video_info">Videobeskrivelse</string>
+    <string name="original_language">মূল ভাষা</string>
 </resources>

--- a/common/src/main/res/values-pt-rBR/strings.xml
+++ b/common/src/main/res/values-pt-rBR/strings.xml
@@ -673,4 +673,5 @@
   <string name="applying_fix">Não feche o Tocador. Aplicando as correções...</string>
   <string name="video_disabled">Video Desabilitado</string>
   <string name="calm_msg">Nós estamos corrigindo as mudanças. Verifique pelas próximas atualizações</string>
+    <string name="original_language">Idioma original</string>
 </resources>

--- a/common/src/main/res/values-pt-rPT/strings.xml
+++ b/common/src/main/res/values-pt-rPT/strings.xml
@@ -666,4 +666,5 @@
   <string name="auto_backup">Backup automático</string>
   <string name="repeat_mode_reverse_list">Reproduzir listas de reprodução ou vídeos dos canais por ordem inversa</string>
   <string name="disable_stream_buffer_desc">Correção para situações em que a emissão em direto está muito atrasada. Nota: pode provocar paragens.</string>
+    <string name="original_language">Idioma original</string>
 </resources>

--- a/common/src/main/res/values-ru/strings.xml
+++ b/common/src/main/res/values-ru/strings.xml
@@ -680,4 +680,5 @@
     <string name="screen_dimming_amount">Степень затемнения экрана</string>
     <string name="screen_dimming_timeout">Тайм-аут затемнения экрана</string>
     <string name="playlists_rows">Отображать раздел Плейлисты в виде строк</string>
+    <string name="original_language">Исходный язык</string>
 </resources>

--- a/common/src/main/res/values-tr/strings.xml
+++ b/common/src/main/res/values-tr/strings.xml
@@ -689,4 +689,5 @@
     <string name="screen_dimming_amount">Ekran karartma miktarı</string>
     <string name="screen_dimming_timeout">Ekran karartma zaman aşımı</string>
     <string name="playlists_rows">Oynatma listelerini satır olarak göster</string>
+    <string name="original_language">Orijinal dil</string>
 </resources>

--- a/common/src/main/res/values-zh-rTW/strings.xml
+++ b/common/src/main/res/values-zh-rTW/strings.xml
@@ -677,4 +677,5 @@
   <string name="recommended">推薦</string>
   <string name="add_to_subscriptions_group">將頻道新增/移除到訂閱群組</string>
   <string name="new_subscriptions_group">新群組</string>
+    <string name="original_language">原始語言</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -687,4 +687,5 @@
     <string name="screen_dimming_amount">Screen dimming amount</string>
     <string name="screen_dimming_timeout">Screen dimming timeout</string>
     <string name="playlists_rows">Show Playlists section as rows</string>
+    <string name="original_language">Original language</string>
 </resources>


### PR DESCRIPTION
Hi,
This is a simple feature that adds an "original language" option in the audio language track selection menu. 

I watch french and english content, and since some channels now use AI for auto translating their voices in their videos i have to go back and forth betwen english and french in the audio track selection.
so this is a feature that eliminates that issue for me (and hopefully other person as well)

Thanks :)
