### PR TITLE
subtitles: remember category rework

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/PlayerUIController.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/PlayerUIController.java
@@ -208,7 +208,8 @@ public class PlayerUIController extends BasePlayerController {
             settingsPresenter.showDialog();
         }));
 
-        settingsPresenter.appendSingleSwitch(AppDialogUtil.createSubtitleChannelOption(getContext()));
+        OptionCategory rememberCategory = AppDialogUtil.createSubtitlesRememberCategory(getContext());
+        settingsPresenter.appendRadioCategory(rememberCategory.title, rememberCategory.options);
 
         OptionCategory stylesCategory = AppDialogUtil.createSubtitleStylesCategory(getContext());
         settingsPresenter.appendRadioCategory(stylesCategory.title, stylesCategory.options);
@@ -761,11 +762,14 @@ public class PlayerUIController extends BasePlayerController {
     }
 
     private boolean isSubtitleEnabled() {
-        return !mPlayerData.isSubtitlesPerChannelEnabled() || mPlayerData.isSubtitlesPerChannelEnabled(getChannelId());
+        return (
+                mPlayerData.getSubtitleRemember() == PlayerData.SUBTITLES_REMEMBER_PER_CHANNEL && mPlayerData.isSubtitlesPerChannelEnabled(getChannelId()) ||
+                        mPlayerData.getSubtitleRemember() == PlayerData.SUBTITLES_REMEMBER_GLOBAL
+        );
     }
 
     private void enableSubtitleForChannel(boolean enable) {
-        if (getPlayer() == null || !mPlayerData.isSubtitlesPerChannelEnabled()) {
+        if (getPlayer() == null || mPlayerData.getSubtitleRemember() != PlayerData.SUBTITLES_REMEMBER_PER_CHANNEL) {
             return;
         }
 

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/VideoStateController.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/VideoStateController.java
@@ -400,7 +400,7 @@ public class VideoStateController extends BasePlayerController {
     private void restoreSubtitleFormat() {
         FormatItem result = mPlayerData.getFormat(FormatItem.TYPE_SUBTITLE);
 
-        if (mPlayerData.isSubtitlesPerChannelEnabled()) {
+        if (mPlayerData.getSubtitleRemember() == PlayerData.SUBTITLES_REMEMBER_PER_CHANNEL) {
             result = mPlayerData.isSubtitlesPerChannelEnabled(getPlayer().getVideo().channelId) ? mPlayerData.getLastSubtitleFormat() : FormatItem.SUBTITLE_NONE;
         }
 

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/settings/SubtitleSettingsPresenter.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/settings/SubtitleSettingsPresenter.java
@@ -26,10 +26,10 @@ public class SubtitleSettingsPresenter extends BasePresenter<Void> {
     public void show() {
         AppDialogPresenter settingsPresenter = AppDialogPresenter.instance(getContext());
 
-        settingsPresenter.appendSingleSwitch(AppDialogUtil.createSubtitleChannelOption(getContext()));
         // Can't work properly. There is no robust language detection.
         //appendSubtitleLanguageCategory(settingsPresenter);
         appendMoreSubtitlesSwitch(settingsPresenter);
+        appendSubtitlesRememberCategory(settingsPresenter);
         appendSubtitleStyleCategory(settingsPresenter);
         appendSubtitleSizeCategory(settingsPresenter);
         appendSubtitlePositionCategory(settingsPresenter);
@@ -64,6 +64,11 @@ public class SubtitleSettingsPresenter extends BasePresenter<Void> {
     //
     //    settingsPresenter.appendRadioCategory(subtitleLanguageTitle, options);
     //}
+
+    private void appendSubtitlesRememberCategory(AppDialogPresenter settingsPresenter) {
+        OptionCategory category = AppDialogUtil.createSubtitlesRememberCategory(getContext());
+        settingsPresenter.appendRadioCategory(category.title, category.options);
+    }
 
     private void appendSubtitleStyleCategory(AppDialogPresenter settingsPresenter) {
         OptionCategory category = AppDialogUtil.createSubtitleStylesCategory(getContext());

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/prefs/PlayerData.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/prefs/PlayerData.java
@@ -37,6 +37,9 @@ public class PlayerData extends DataChangeBase implements PlayerEngineConstants,
     public static final int SEEK_PREVIEW_SINGLE = 1;
     public static final int SEEK_PREVIEW_CAROUSEL_SLOW = 2;
     public static final int SEEK_PREVIEW_CAROUSEL_FAST = 3;
+    public static final int SUBTITLES_REMEMBER_DONT = 0;
+    public static final int SUBTITLES_REMEMBER_PER_CHANNEL = 1;
+    public static final int SUBTITLES_REMEMBER_GLOBAL = 2;
     @SuppressLint("StaticFieldLeak")
     private static PlayerData sInstance;
     private final AppPrefs mPrefs;
@@ -90,7 +93,7 @@ public class PlayerData extends DataChangeBase implements PlayerEngineConstants,
     private boolean mIsLiveChatEnabled;
     private List<FormatItem> mLastSubtitleFormats;
     private List<String> mEnabledSubtitlesPerChannel;
-    private boolean mIsSubtitlesPerChannelEnabled;
+    private int mSubtitlesRemember;
     private boolean mIsSpeedPerChannelEnabled;
     private final Map<String, SpeedItem> mSpeeds = new HashMap<>();
     private float mPitch;
@@ -444,15 +447,6 @@ public class PlayerData extends DataChangeBase implements PlayerEngineConstants,
         return mEnabledSubtitlesPerChannel.contains(channelId);
     }
 
-    public void enableSubtitlesPerChannel(boolean enable) {
-        mIsSubtitlesPerChannelEnabled = enable;
-        persistState();
-    }
-
-    public boolean isSubtitlesPerChannelEnabled() {
-        return mIsSubtitlesPerChannelEnabled;
-    }
-
     public void setVideoBufferType(int type) {
         mVideoBufferType = type;
         persistState();
@@ -490,6 +484,13 @@ public class PlayerData extends DataChangeBase implements PlayerEngineConstants,
 
     public void setSubtitlePosition(float position) {
         mSubtitlePosition = position;
+        persistState();
+    }
+
+    public int getSubtitleRemember() { return mSubtitlesRemember; }
+
+    public void setSubtitleRemember(int mode) {
+        mSubtitlesRemember = mode;
         persistState();
     }
 
@@ -823,12 +824,12 @@ public class PlayerData extends DataChangeBase implements PlayerEngineConstants,
         mSubtitleLanguage = Helpers.parseStr(split, 53, LocaleUtility.getCurrentLanguage(mPrefs.getContext()));
         //String enabledSubtitles = Helpers.parseStr(split, 54);
         mEnabledSubtitlesPerChannel = Helpers.parseStrList(split, 54);
-        mIsSubtitlesPerChannelEnabled = Helpers.parseBoolean(split, 55, true);
         mIsSpeedPerChannelEnabled = Helpers.parseBoolean(split, 56, true);
         String[] speeds = Helpers.parseArray(split, 57);
         mPitch = Helpers.parseFloat(split, 58, 1.0f);
         mIsSkipShortsEnabled = Helpers.parseBoolean(split, 59, false);
         mLastAudioLanguages = Helpers.parseStrList(split, 60);
+        mSubtitlesRemember = Helpers.parseInt(split, 61, SUBTITLES_REMEMBER_DONT);
 
         if (speeds != null) {
             for (String speedSpec : speeds) {
@@ -854,8 +855,8 @@ public class PlayerData extends DataChangeBase implements PlayerEngineConstants,
                 mIsGlobalEndingTimeEnabled, mIsEndingTimeEnabled, mIsDoubleRefreshRateEnabled, mIsSeekConfirmPlayEnabled,
                 mStartSeekIncrementMs, null, mSubtitleScale, mPlayerVolume, mIsTooltipsEnabled, mSubtitlePosition, mIsNumberKeySeekEnabled,
                 mIsSkip24RateEnabled, mAfrPauseMs, mIsLiveChatEnabled, mLastSubtitleFormats, mLastSpeed, mVideoRotation,
-                mVideoZoom, mRepeatMode, mAudioLanguage, mSubtitleLanguage, mEnabledSubtitlesPerChannel, mIsSubtitlesPerChannelEnabled,
-                mIsSpeedPerChannelEnabled, Helpers.mergeArray(mSpeeds.values().toArray()), mPitch, mIsSkipShortsEnabled, mLastAudioLanguages
+                mVideoZoom, mRepeatMode, mAudioLanguage, mSubtitleLanguage, mEnabledSubtitlesPerChannel, mIsSpeedPerChannelEnabled,
+                Helpers.mergeArray(mSpeeds.values().toArray()), mPitch, mIsSkipShortsEnabled, mLastAudioLanguages, mSubtitlesRemember
         ));
 
         onDataChange();

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/utils/AppDialogUtil.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/utils/AppDialogUtil.java
@@ -81,6 +81,7 @@ public class AppDialogUtil {
     private static final int SUBTITLE_STYLES_ID = 45;
     private static final int SUBTITLE_SIZE_ID = 46;
     private static final int SUBTITLE_POSITION_ID = 47;
+    private static final int SUBTITLE_REMEMBER_ID = 48;
     private static final int FILE_PICKER_REQUEST_CODE = 205;
 
     /**
@@ -461,18 +462,32 @@ public class AppDialogUtil {
         return OptionCategory.from(PITCH_EFFECT_ID, OptionCategory.TYPE_RADIO_LIST, title, options);
     }
 
+    public static OptionCategory createSubtitlesRememberCategory(Context context) {
+        PlayerData playerData = PlayerData.instance(context);
+        List<OptionItem> options = new ArrayList<>();
+
+        options.add(UiOptionItem.from(context.getString(R.string.subtitle_remember_dont),
+                optionItem -> playerData.setSubtitleRemember(PlayerData.SUBTITLES_REMEMBER_DONT),
+                playerData.getSubtitleRemember() == PlayerData.SUBTITLES_REMEMBER_DONT
+        ));
+
+        options.add(UiOptionItem.from(context.getString(R.string.subtitle_remember_per_channel),
+                optionItem -> playerData.setSubtitleRemember(PlayerData.SUBTITLES_REMEMBER_PER_CHANNEL),
+                playerData.getSubtitleRemember() == PlayerData.SUBTITLES_REMEMBER_PER_CHANNEL
+        ));
+
+        options.add(UiOptionItem.from(context.getString(R.string.subtitle_remember_global),
+                optionItem -> playerData.setSubtitleRemember(PlayerData.SUBTITLES_REMEMBER_GLOBAL),
+                playerData.getSubtitleRemember() == PlayerData.SUBTITLES_REMEMBER_GLOBAL
+        ));
+
+        return OptionCategory.from(SUBTITLE_REMEMBER_ID, OptionCategory.TYPE_RADIO_LIST, context.getString(R.string.subtitle_remember_title), options);
+    }
+
     public static OptionCategory createSubtitleStylesCategory(Context context) {
         String subtitleStyleTitle = context.getString(R.string.subtitle_style);
 
         return OptionCategory.from(SUBTITLE_STYLES_ID, OptionCategory.TYPE_RADIO_LIST, subtitleStyleTitle, createSubtitleStyles(context));
-    }
-
-    public static OptionItem createSubtitleChannelOption(Context context) {
-        PlayerData playerData = PlayerData.instance(context);
-        return UiOptionItem.from(context.getString(R.string.subtitle_remember),
-                optionItem -> playerData.enableSubtitlesPerChannel(optionItem.isSelected()),
-                playerData.isSubtitlesPerChannelEnabled()
-        );
     }
 
     @TargetApi(19)

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -600,6 +600,10 @@
     <string name="content_block_stop_excluding_channel">Stop excluding this channel from SponsorBlock</string>
     <string name="player_chapter_notification">Quick advance through the chapters using the popup notification</string>
     <string name="subtitle_remember">Remember enabled subtitles per each channel</string>
+    <string name="subtitle_remember_title">Remember enabled subtitles</string>
+    <string name="subtitle_remember_dont">Do not remember</string>
+    <string name="subtitle_remember_per_channel">Remember for each channel</string>
+    <string name="subtitle_remember_global">Remember globally</string>
     <string name="amazon_frame_drop_fix">Frame drop fix #2</string>
     <string name="amazon_frame_drop_fix_desc">Intended for Amazon Stick devices. May work on other devices too.</string>
     <string name="default_stack_desc">Built-in network engine. This engine may have better stability in certain situations.</string>


### PR DESCRIPTION
Hi,
I needed a way to enable subtitles for all channel regardless of the channel watched, and since I couldn't find a way in the settings I added it.
I replaced the "Remember enabled subtitles per each channel" switch with a new category called "Remember enabled subtitles" with the following options: "Do not remember", "Remember for each channel", "Remember globally". The logic for the first two options should be the same as before, but the new third option ignores the enabled subtitles channels and shows the subtitles at all times.

![image](https://github.com/user-attachments/assets/cfcfeaf7-b311-4007-8c15-1cfd014ece32)
![image](https://github.com/user-attachments/assets/1dbb81f9-e736-4ac0-9b19-21a93c6d34de)

It should be almost ready to merge, but there's a couple things that should be kept in mind:
- the category ID in AppDialogUtil.java is at the end of the subtitle IDs, no idea if you want to keep the IDs in order with the UI elements
- same thing with the index for the setting in persistState() inside of PlayerData.java, I added the setting at the end to avoid breaking existing saves
- kept the "subtitle_remember" string in strings.xml as I don't know how to proceed with unused strings. I will be able to add a couple more languages for the new strings in another commit in the future

Thank you for reading and let me know if there are any issues