### PR TITLE
Add UI settings for duplicate video filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ tmp/
 fabric.properties
 *BAK.java
 hs_err_pid*.log
+
+# Exclude main CustomInit.java (allow local customizations)
+common/src/main/java/com/liskovsoft/smartyoutubetv2/common/utils/CustomInit.java

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,3 @@ tmp/
 fabric.properties
 *BAK.java
 hs_err_pid*.log
-
-# Exclude main CustomInit.java (allow local customizations)
-common/src/main/java/com/liskovsoft/smartyoutubetv2/common/utils/CustomInit.java

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/settings/GeneralSettingsPresenter.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/settings/GeneralSettingsPresenter.java
@@ -176,6 +176,14 @@ public class GeneralSettingsPresenter extends BasePresenter<Void> {
                 option -> mMediaServiceData.hideContent(MediaServiceData.CONTENT_UPCOMING_CHANNEL, option.isSelected()),
                 mMediaServiceData.isContentHidden(MediaServiceData.CONTENT_UPCOMING_CHANNEL)));
 
+        options.add(UiOptionItem.from(getContext().getString(R.string.hide_duplicates),
+                option -> mMediaServiceData.hideContent(MediaServiceData.CONTENT_DUPLICATES, option.isSelected()),
+                mMediaServiceData.isContentHidden(MediaServiceData.CONTENT_DUPLICATES)));
+
+        options.add(UiOptionItem.from(getContext().getString(R.string.hide_duplicates_exclude_recommended),
+                option -> mMediaServiceData.hideContent(MediaServiceData.CONTENT_DUPLICATES_EXCLUDE_RECOMMENDED, option.isSelected()),
+                mMediaServiceData.isContentHidden(MediaServiceData.CONTENT_DUPLICATES_EXCLUDE_RECOMMENDED)));
+
         settingsPresenter.appendCheckedCategory(getContext().getString(R.string.hide_unwanted_content), options);
     }
 

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -682,6 +682,8 @@
     <string name="video_disabled">Video disabled</string>
     <string name="applying_fix">Don\'t close the player. Applying the fix…</string>
     <string name="hide_mixes">Hide Mixes</string>
+    <string name="hide_duplicates">Hide duplicate videos</string>
+    <string name="hide_duplicates_exclude_recommended">Hide duplicate videos (exclude \"Recommended\")</string>
     <string name="player_global_focus_desc">This feature affects which player button will receive focus when navigating between player button rows</string>
     <string name="disable_network_error_fixing">Disable automatic network error fixing</string>
     <string name="disable_network_error_fixing_desc">You probably need to enable this option if you\'re using a VPN</string>


### PR DESCRIPTION
In relation to [MediaServiceCore pull:18](https://github.com/yuliskov/MediaServiceCore/pull/18/)

Adds `Hide duplicate videos` and `Hide duplicate videos (exclude "Recommended")` options to `General` settings > `Hide videos`