### PR TITLE
Create setting to allow playback to be paused after each video in playback queue when "Pause playback after each video" playback mode is set in the player

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/VideoLoaderController.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/VideoLoaderController.java
@@ -737,8 +737,8 @@ public class VideoLoaderController extends BasePlayerController {
                 break;
             case PlayerConstants.PLAYBACK_MODE_PAUSE:
                 // Stop player after each video.
-                // Except when playing from queue
-                if (mPlaylist.getNext() != null) {
+                // Except when playing from queue, if not overridden in settings
+                if (mPlaylist.getNext() != null && !getPlayerTweaksData().isPauseAfterEachVideoInQueueEnabled()) {
                     loadNext();
                 } else {
                     getPlayer().setPositionMs(getPlayer().getDurationMs());

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/settings/PlayerSettingsPresenter.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/settings/PlayerSettingsPresenter.java
@@ -629,6 +629,11 @@ public class PlayerSettingsPresenter extends BasePresenter<Void> {
                 option -> mPlayerTweaksData.setRealChannelIconEnabled(option.isSelected()),
                 mPlayerTweaksData.isRealChannelIconEnabled()));
 
+        options.add(UiOptionItem.from(getContext().getString(R.string.pause_after_each_video_in_queue),
+                getContext().getString(R.string.pause_after_each_video_in_queue_desc),
+                option -> mPlayerTweaksData.setPauseAfterEachVideoInQueueEnabled(option.isSelected()),
+                mPlayerTweaksData.isPauseAfterEachVideoInQueueEnabled()));
+
         settingsPresenter.appendCheckedCategory(getContext().getString(R.string.player_other), options);
     }
 

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/prefs/PlayerTweaksData.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/prefs/PlayerTweaksData.java
@@ -101,6 +101,7 @@ public class PlayerTweaksData implements ProfileChangeListener {
     private boolean mIsAudioFocusEnabled;
     private boolean mIsNetworkErrorFixingDisabled;
     private boolean mIsDontResizeVideoToFitDialogEnabled;
+    private boolean mIsPauseAfterEachVideoInQueueEnabled;
     private final Runnable mPersistDataInt = this::persistDataInt;
 
     private PlayerTweaksData(Context context) {
@@ -612,6 +613,15 @@ public class PlayerTweaksData implements ProfileChangeListener {
         persistData();
     }
 
+    public boolean isPauseAfterEachVideoInQueueEnabled() {
+        return mIsPauseAfterEachVideoInQueueEnabled;
+    }
+
+    public void setPauseAfterEachVideoInQueueEnabled(boolean enable) {
+        mIsPauseAfterEachVideoInQueueEnabled = enable;
+        persistData();
+    }
+
     private void restoreData() {
         String data = mPrefs.getProfileData(VIDEO_PLAYER_TWEAKS_DATA);
 
@@ -678,6 +688,7 @@ public class PlayerTweaksData implements ProfileChangeListener {
         //mIsPersistentAntiBotFixEnabled = Helpers.parseBoolean(split, 53, false);
         mIsAudioFocusEnabled = Helpers.parseBoolean(split, 54, true);
         mIsDontResizeVideoToFitDialogEnabled = Helpers.parseBoolean(split, 55, false);
+        mIsPauseAfterEachVideoInQueueEnabled = Helpers.parseBoolean(split, 56, false);
 
         updateDefaultValues();
     }
@@ -704,7 +715,7 @@ public class PlayerTweaksData implements ProfileChangeListener {
                 mScreenOffDimmingPercents, mIsBootScreenOffEnabled, mIsPlayerUiOnNextEnabled, mIsPlayerAutoVolumeEnabled, mIsSimplePlayerNavigationEnabled,
                 mIsUnsafeAudioFormatsEnabled, null, mIsLoopShortsEnabled, mIsQuickSkipShortsEnabled, mIsRememberPositionOfLiveVideosEnabled,
                 mIsOculusQuestFixEnabled, null, mIsExtraLongSpeedListEnabled, mIsQuickSkipVideosEnabled, mIsNetworkErrorFixingDisabled, mIsCommentsPlacedLeft,
-                null, mIsAudioFocusEnabled, mIsDontResizeVideoToFitDialogEnabled
+                null, mIsAudioFocusEnabled, mIsDontResizeVideoToFitDialogEnabled, mIsPauseAfterEachVideoInQueueEnabled
                 ));
     }
 

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -708,4 +708,6 @@
     <string name="card_unlocalized_titles">Unlocalized video titles</string>
     <string name="dont_resize_video_to_fit_dialog">Don\'t resize video to fit dialog</string>
     <string name="typing_corrections">Disable auto-correction while typing text</string>
+    <string name="pause_after_each_video_in_queue">Pause after each video in playback queue</string>
+    <string name="pause_after_each_video_in_queue_desc">This takes effect when \"Pause playback after each video\" playback mode is selected in the player</string>
 </resources>


### PR DESCRIPTION
Originally created https://github.com/yuliskov/SmartTube/issues/4937, but after some digging realises it's intended behavior. This PR adds a setting in Player -> Misc that allows playback to be paused after each video in the playback queue when "Pause playback after each video" is set in the player. 

Note: The same change can be applied to the "Stop playback after one video" playback mode, but that is not done in this PR.