### PR TITLE
feat: Pause video on seek

### DIFF
--- a/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/tv/ui/mod/leanback/playerglue/framedrops/PlaybackTransportControlGlue.java
+++ b/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/tv/ui/mod/leanback/playerglue/framedrops/PlaybackTransportControlGlue.java
@@ -354,9 +354,7 @@ public class PlaybackTransportControlGlue<T extends PlayerAdapter>
             // otherwise we will call seekTo() and may need to restore the original position.
             mPositionBeforeSeek = mSeekProvider == null ? mPlayerAdapter.getCurrentPosition() : -1;
             mLastUserPosition = -1;
-            if (!mPlayerData.isSeekConfirmPlayEnabled()) {
-                pause();
-            }
+            pause();
         }
 
         @Override
@@ -383,13 +381,9 @@ public class PlaybackTransportControlGlue<T extends PlayerAdapter>
                 }
             }
             mIsSeek = false;
-            if (!mPausedBeforeSeek) {
-                play();
-            } else {
-                mPlayerAdapter.setProgressUpdatingEnabled(false);
-                // we neeed update UI since PlaybackControlRow still saves previous position.
-                onUpdateProgress();
-            }
+            mPlayerAdapter.setProgressUpdatingEnabled(false);
+            // we neeed update UI since PlaybackControlRow still saves previous position.
+            onUpdateProgress();
         }
     };
 


### PR DESCRIPTION
This change modifies the playback behavior so that the video pauses when the user seeks forward or backward. The video will remain paused at the new position until the user explicitly presses 'play' to resume.

This behavior is common in many streaming applications and improves usability by allowing the user to precisely select a point in the video timeline without the video playing automatically.