### PR TITLE
Add option to disable AV1 support in developer player settings

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/settings/PlayerSettingsPresenter.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/settings/PlayerSettingsPresenter.java
@@ -382,6 +382,16 @@ public class PlayerSettingsPresenter extends BasePresenter<Void> {
                 option -> GlobalPreferences.instance(getContext()).setChannelsServiceEnabled(!option.isSelected()),
                 !GlobalPreferences.instance(getContext()).isChannelsServiceEnabled()));
 
+        // Disable AV1 support (useful for devices with only software AV1 decoding)
+        options.add(UiOptionItem.from(getContext().getString(R.string.disable_av1_support),
+                getContext().getString(R.string.disable_av1_support_desc),
+                option -> {
+                    GlobalPreferences.instance(getContext()).setAV1Disabled(option.isSelected());
+                    // Apply runtime override
+                    com.liskovsoft.sharedutils.helpers.Helpers.setAV1Disabled(option.isSelected());
+                },
+                GlobalPreferences.instance(getContext()).isAV1Disabled()));
+
         options.add(UiOptionItem.from(getContext().getString(R.string.hide_settings_section),
                 option -> {
                     mSidebarService.enableSettingsSection(!option.isSelected());

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -398,6 +398,8 @@
     <string name="ambilight_ratio_fix">Ambilight/Aspect ratio/Video scale/Screenshots fix</string>
     <string name="force_legacy_codecs_desc">Significantly improves performance on low-end devices. Maximum resolution is 720p.</string>
     <string name="force_legacy_codecs">Force legacy codecs (720p)</string>
+    <string name="disable_av1_support">Disable AV1 support</string>
+    <string name="disable_av1_support_desc">Avoid selecting AV1 streams (useful for devices without hardware AV1 decoding).</string>
     <string name="live_stream_fix_desc">Warn, this tweak disables the rewinding of streams. Significantly improves live stream performance on low-end devices. Maximum resolution is 1080p.</string>
     <string name="live_stream_fix_4k_desc">Warn, this tweak disables the rewinding of streams. Significantly improves live stream performance. Maximum resolution is 4K.</string>
     <string name="live_stream_fix">Live stream fix (1080p)</string>


### PR DESCRIPTION
Introduced a new player setting to disable AV1 stream selection, useful for devices lacking hardware AV1 decoding. Added corresponding UI strings.

This should both fix wrong defaulting to AV1 in specific cases like #5049. As well as preventing selecting AV1 codec at all making it easier to switch between resolutions and or framerate choices. Tested on Chromecast with Google TV 4k.