### PR TITLE
Fix(player): Correct volume booster gain calculation

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/exoplayer/other/VolumeBooster.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/exoplayer/other/VolumeBooster.java
@@ -50,15 +50,10 @@ public class VolumeBooster implements AudioListener {
         try {
             mBooster = new LoudnessEnhancer(audioSessionId);
             mBooster.setEnabled(mIsEnabled);
-
-            //double log2 = Math.log(mVolume) / Math.log(2);
-            //double gainMb = 10 * log2 * 100;
-            //mBooster.setTargetGain((int) gainMb);
-
-            double gainMb = 20 * Math.log10(mVolume * 3) * 100;
-            mBooster.setTargetGain((int) gainMb);
-
-            //mBooster.setTargetGain((int) (1000 * mVolume));
+ 
+            // Convert linear volume multiplier to millibels (100mB = 1dB)
+            double gainMillibels = 20 * Math.log10(mVolume) * 100;
+            mBooster.setTargetGain((int) Math.round(gainMillibels));
 
             mIsSupported = true;
         } catch (RuntimeException | UnsatisfiedLinkError | NoClassDefFoundError | NoSuchFieldError e) { // Cannot initialize effect engine


### PR DESCRIPTION
The formula to convert the linear volume multiplier to millibels for the LoudnessEnhancer was incorrect.

The previous implementation used a hardcoded multiplier. This commit corrects the formula to the standard `Gain (mB) = 20 * log10(volume_multiplier) * 100`, ensuring the target gain is set correctly as per the [Android API](https://developer.android.com/reference/android/media/audiofx/LoudnessEnhancer).

fixes #4553 #4612