### PR TITLE
Add option to control autoplay behavior for Watch Later playlist

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/settings/PlayerSettingsPresenter.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/settings/PlayerSettingsPresenter.java
@@ -520,6 +520,10 @@ public class PlayerSettingsPresenter extends BasePresenter<Void> {
                 option -> mPlayerTweaksData.setSectionPlaylistEnabled(option.isSelected()),
                 mPlayerTweaksData.isSectionPlaylistEnabled()));
 
+        options.add(UiOptionItem.from(getContext().getString(R.string.player_treat_watch_later_as_playlist),
+                option -> mPlayerTweaksData.setTreatWatchLaterAsPlaylistEnabled(option.isSelected()),
+                mPlayerTweaksData.isTreatWatchLaterAsPlaylistEnabled()));
+
         options.add(UiOptionItem.from(getContext().getString(R.string.player_chapter_notification2),
                 option -> mPlayerTweaksData.setChapterNotificationEnabled(option.isSelected()),
                 mPlayerTweaksData.isChapterNotificationEnabled()));

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/prefs/PlayerTweaksData.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/prefs/PlayerTweaksData.java
@@ -83,6 +83,7 @@ public class PlayerTweaksData implements ProfileChangeListener {
     private boolean mUnlockAllFormats;
     private boolean mIsBufferOnStreamsDisabled;
     private boolean mIsSectionPlaylistEnabled;
+    private boolean mIsTreatWatchLaterAsPlaylistEnabled;
     private boolean mIsScreenOffTimeoutEnabled;
     private boolean mIsBootScreenOffEnabled;
     private int mScreenOffTimeoutSec;
@@ -452,6 +453,15 @@ public class PlayerTweaksData implements ProfileChangeListener {
         persistData();
     }
 
+    public boolean isTreatWatchLaterAsPlaylistEnabled() {
+        return mIsTreatWatchLaterAsPlaylistEnabled;
+    }
+
+    public void setTreatWatchLaterAsPlaylistEnabled(boolean enable) {
+        mIsTreatWatchLaterAsPlaylistEnabled = enable;
+        persistData();
+    }
+
     public boolean isScreenOffTimeoutEnabled() {
         return mIsScreenOffTimeoutEnabled;
     }
@@ -689,6 +699,7 @@ public class PlayerTweaksData implements ProfileChangeListener {
         mIsAudioFocusEnabled = Helpers.parseBoolean(split, 54, true);
         mIsDontResizeVideoToFitDialogEnabled = Helpers.parseBoolean(split, 55, false);
         mIsSuggestionsHorizontallyScrolled = Helpers.parseBoolean(split, 56, false);
+        mIsTreatWatchLaterAsPlaylistEnabled = Helpers.parseBoolean(split, 57, true);
 
         updateDefaultValues();
     }
@@ -715,7 +726,7 @@ public class PlayerTweaksData implements ProfileChangeListener {
                 mScreenOffDimmingPercents, mIsBootScreenOffEnabled, mIsPlayerUiOnNextEnabled, mIsPlayerAutoVolumeEnabled, mIsSyncRowButtonIndexEnabled,
                 mIsUnsafeAudioFormatsEnabled, null, mIsLoopShortsEnabled, mIsQuickSkipShortsEnabled, mIsRememberPositionOfLiveVideosEnabled,
                 mIsOculusQuestFixEnabled, null, mIsExtraLongSpeedListEnabled, mIsQuickSkipVideosEnabled, mIsNetworkErrorFixingDisabled, mIsCommentsPlacedLeft,
-                null, mIsAudioFocusEnabled, mIsDontResizeVideoToFitDialogEnabled, mIsSuggestionsHorizontallyScrolled
+                null, mIsAudioFocusEnabled, mIsDontResizeVideoToFitDialogEnabled, mIsSuggestionsHorizontallyScrolled, mIsTreatWatchLaterAsPlaylistEnabled
                 ));
     }
 

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -591,6 +591,7 @@
     <string name="play_from_start">Play from start</string>
     <string name="header_kids_home">Kids</string>
     <string name="player_section_playlist">Use current section contents as a playlist</string>
+    <string name="player_treat_watch_later_as_playlist">Autoplay treats Watch Later as a playlist</string>
     <string name="header_trending">Trending</string>
     <string name="screensaver">Screensaver</string>
     <string name="player_screen_off_timeout">Screen off timeout</string>


### PR DESCRIPTION
This PR introduces a new setting to control how autoplay behaves for videos in the "Watch Later" playlist.

**Motivation:**

Currently, the app always treats the "Watch Later" list as a playlist for autoplay. When one video from the list ends, the next one in the list automatically begins.

For users who use "Watch Later" as a temporary list for individual videos, the expected behavior is to see standard video suggestions after a video finishes, not to automatically play through the entire list.

**Proposed Change:**
- A new setting, "**Autoplay treats Watch Later as a playlist**" is added under `Settings > Player > Misc`.
- This setting is **enabled by default** to ensure the existing behavior remains unchanged for current users.
- When a user disables this setting, watching a video from "Watch Later" will be followed by standard suggestions instead of the next video in the playlist.

This change offers more flexibility, allowing users to tailor the app's behavior to their preferred workflow.

Let me know what you think