### PR TITLE
add support for x86_64 abis

### DIFF
--- a/smarttubetv/build.gradle
+++ b/smarttubetv/build.gradle
@@ -70,7 +70,7 @@ android {
                 reset()
                 // Note, Android could soon start warning users when they run 32-bit apps
                 //include 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a' //select ABIs to build APKs for
-                include 'armeabi-v7a', 'x86', 'arm64-v8a' // v7a main build, x86 for WSL, v8a for Pixel Tablet (no 32 bit support)
+                include 'armeabi-v7a', 'x86', 'x86_64', 'arm64-v8a' // v7a main build, x86 for WSL, v8a for Pixel Tablet (no 32 bit support)
                 universalApk false //generate an additional APK that contains all the ABIs
             }
         }


### PR DESCRIPTION
Newer devices doesn't have 32 bits libs so x86 build is not compatible