### PR TITLE
Update Virus Total scan

### DIFF
--- a/.github/workflows/virustotal_scan.yml
+++ b/.github/workflows/virustotal_scan.yml
@@ -57,11 +57,11 @@ jobs:
             done
 
             if [ "$status" != "completed" ]; then
-              echo " - [![VT](https://badges.cssnr.com/vt/id/$sha256) $filename](https://www.virustotal.com/gui/file/$sha256) — BAD ❌ (analysis incomplete)" >> vt_report.txt
+              echo " - [![VT](https://badges.cssnr.com/vt/id/$sha256?end=red&n=1) $filename](https://www.virustotal.com/gui/file/$sha256) — BAD ❌ (analysis incomplete)" >> vt_report.txt
             elif [ "$malicious" -gt 0 ]; then
-              echo " - [![VT](https://badges.cssnr.com/vt/id/$sha256) $filename](https://www.virustotal.com/gui/file/$sha256) — BAD ❌" >> vt_report.txt
+              echo " - [![VT](https://badges.cssnr.com/vt/id/$sha256?end=red&n=1) $filename](https://www.virustotal.com/gui/file/$sha256) — BAD ❌" >> vt_report.txt
             else
-              echo " - [![VT](https://badges.cssnr.com/vt/id/$sha256) $filename](https://www.virustotal.com/gui/file/$sha256)" >> vt_report.txt
+              echo " - [![VT](https://badges.cssnr.com/vt/id/$sha256?end=red&n=1) $filename](https://www.virustotal.com/gui/file/$sha256)" >> vt_report.txt
             fi
           done
 
@@ -78,4 +78,5 @@ jobs:
         run: |
           tag=$(cat release_tag.txt)
           echo "VirusTotal quick scan finished and report added to release $tag"
+
 


### PR DESCRIPTION
* Compatible with [Immutable releases](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases) and release draft
* Add links to Virus Total results
* Add real time status update with [Virus Total badge](https://github.com/cssnr/virustotal-action/discussions/27)
* Need manual trigger when release is draft and files are added, because automatic trigger for draft release don't work
* Raise scanning timeout to 225 seconds, because 150 seconds timed out when testing

Users with this can see that SHA256 for files is the same in file list, in Virus Total links and badges. 
Users can click on links and see Virus Total.
This will work with [Immutable releases](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases) for better security.

[Here is example release.](https://github.com/Edward202511/SmartTube/releases/tag/30.59s)
OK ✅ text is removed. Good status is visible in badge. If virus will be found later badge will update and not be green.

To use this with Immutable release do these steps:

1. Create the release as a draft.
2. Write Release title and Release notes.
3. Attach all associated APK files to the draft release.
4. Run Github Actions workflow and wait for it complete.
5. Publish the draft release.