### PR TITLE
Bugfix: account for long lines in comments in getRealMaxLen

### DIFF
--- a/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/tv/ui/widgets/chat/ChatItemMessage.java
+++ b/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/tv/ui/widgets/chat/ChatItemMessage.java
@@ -130,14 +130,11 @@ public class ChatItemMessage implements IMessage {
             return MAX_LENGTH;
         }
 
-        // My additions:
         List<String> splitNoLongLines = new ArrayList<>();
         for (String line : split) {
             while (line.length() > LINE_LENGTH) {
-                // Find last space before LINE_LENGTH
                 int breakPoint = line.lastIndexOf(' ', LINE_LENGTH);
 
-                // If no space found, just break at LINE_LENGTH
                 if (breakPoint == -1) {
                     breakPoint = LINE_LENGTH;
                 }
@@ -145,11 +142,8 @@ public class ChatItemMessage implements IMessage {
                 splitNoLongLines.add(line.substring(0, breakPoint));
                 line = line.substring(breakPoint).trim();
             }
-            // Add remaining part (or whole line if it was short)
             splitNoLongLines.add(line);
         }
-
-        // Then convert back to array and continue with original logic
         split = splitNoLongLines.toArray(new String[0]);
 
         int realCount = 0;


### PR DESCRIPTION
This is a fix to the bug reported here:
- https://github.com/yuliskov/SmartTube/issues/2436
- https://github.com/yuliskov/SmartTube/issues/3596

getRealMaxLen in ChatItemMessage.java relies on line breaks but comments with really long lines will return a higher value than what can actually be displayed. The suggested fix relies on MAX_LENGTH which is conservative (its set to 700 while I think ~1000 can fit) but it gets the job done.

For testing, used the pinned comment here: https://www.youtube.com/watch?v=ZK742uBTywA
Before:
<img width="390" height="591" alt="orig acc" src="https://github.com/user-attachments/assets/d1b1263d-29fc-4016-b184-8cd3b780d568" />
After:
<img width="389" height="590" alt="suggested" src="https://github.com/user-attachments/assets/c2824221-60e5-43ea-b01f-a228905c2c7f" />

AI Disclosure: Feature implemented using AI, but tested manually using Android TV Emulator