### PR TITLE
feat: Allow pausing video while viewing comments

### DIFF
--- a/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/tv/ui/dialogs/AppDialogActivity.java
+++ b/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/tv/ui/dialogs/AppDialogActivity.java
@@ -70,6 +70,18 @@ public class AppDialogActivity extends MotherActivity {
             return false;
         }
 
+        // Forward media keys (play/pause) to playback view so video can be paused while viewing comments
+        if (KeyHelpers.isMediaKey(event.getKeyCode())) {
+            PlaybackView view = PlaybackPresenter.instance(this).getView();
+            if (view instanceof Fragment) {
+                Activity activity = ((Fragment) view).getActivity();
+                if (activity != null) {
+                    activity.dispatchKeyEvent(event);
+                    return true;
+                }
+            }
+        }
+
         // Toggle dialog
         if (!mFragment.isOverlay() && (KeyHelpers.isLeftRightKey(event.getKeyCode()) || KeyHelpers.isMenuKey(event.getKeyCode()))) {
             if (event.getAction() == KeyEvent.ACTION_DOWN) {


### PR DESCRIPTION
Added media key forwarding to allow users to pause/play video while the comments dialog is open. This enables a better viewing experience when reading comments during playback.

Changes:
- AppDialogActivity: Forward media keys to PlaybackActivity
- CommentsPreferenceDialogFragment: Add OnKeyListener to messagesList that forwards media keys (play/pause) to the player