### PR TITLE
Add transfer function and color space to player developer options overlay

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/exoplayer/other/DebugInfoManager.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/exoplayer/other/DebugInfoManager.java
@@ -15,6 +15,7 @@ import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.util.Pair;
+import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.ExoPlayerLibraryInfo;
 import com.google.android.exoplayer2.Format;
@@ -261,6 +262,17 @@ public final class DebugInfoManager implements Runnable, Player.EventListener {
         String videoCodecName = getVideoDecoderNameV2();
         mVideoInfo.add(new Pair<>("Video decoder name", videoCodecName));
         mVideoInfo.add(new Pair<>("Hardware accelerated", String.valueOf(DeviceHelpers.isHardwareAccelerated(videoCodecName))));
+        
+        if (video.colorInfo != null) {
+            String transferFunction = getColorTransferString(video.colorInfo.colorTransfer);
+            if (!transferFunction.equals(NOT_AVAILABLE)) {
+                mVideoInfo.add(new Pair<>("Transfer function", transferFunction));
+            }
+            String colorSpace = getColorSpaceString(video.colorInfo.colorSpace);
+            if (!colorSpace.equals(NOT_AVAILABLE)) {
+                mVideoInfo.add(new Pair<>("Color space", colorSpace));
+            }
+        }
     }
 
     private void appendRuntimeInfo() {
@@ -475,6 +487,40 @@ public final class DebugInfoManager implements Runnable, Player.EventListener {
 
     private String getVideoDecoderNameV2() {
         return ExoUtils.getVideoDecoderName();
+    }
+
+    private String getColorTransferString(int colorTransfer) {
+        if (colorTransfer == Format.NO_VALUE) {
+            return NOT_AVAILABLE;
+        }
+
+        switch (colorTransfer) {
+            case C.COLOR_TRANSFER_SDR:
+                return "Gamma";
+            case C.COLOR_TRANSFER_ST2084:
+                return "PQ (ST.2084)";
+            case C.COLOR_TRANSFER_HLG:
+                return "HLG";
+            default:
+                return NOT_AVAILABLE;
+        }
+    }
+
+    private String getColorSpaceString(int colorSpace) {
+        if (colorSpace == Format.NO_VALUE) {
+            return NOT_AVAILABLE;
+        }
+
+        switch (colorSpace) {
+            case C.COLOR_SPACE_BT601:
+                return "BT.601";
+            case C.COLOR_SPACE_BT709:
+                return "BT.709";
+            case C.COLOR_SPACE_BT2020:
+                return "BT.2020";
+            default:
+                return NOT_AVAILABLE;
+        }
     }
 
     private String getRawDisplayResolution() {


### PR DESCRIPTION
## Add Transfer Function and Color Space to player developer options overlay

### Changes
- Display **Transfer function**: Gamma (SDR), PQ (ST.2084), or HLG
- Display **Color space**: BT.601, BT.709, or BT.2020
- Both values appear in the player's developer options overlay, right after "Hardware accelerated"
- Only displayed when color info is available in the video format

### Technical Details
- Extracts color metadata from ExoPlayer's `Format.colorInfo`
- Uses standard color transfer and color space constants from `C` class
- Follows existing code patterns in `DebugInfoManager`

Youtube already has a precedent of displaying these in "Stats for nerds".

Tested manually on AndroidTV(FireOS) device.