### PR TITLE
Fix up/down skipping in normal videos, fixes #5294

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/PlayerUIController.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/PlayerUIController.java
@@ -762,7 +762,8 @@ public class PlayerUIController extends BasePlayerController {
 
     private boolean handleUpDownSkip(int keyCode) {
         if (getPlayer() == null || getPlayer().isOverlayShown() || getVideo() == null ||
-                getVideo().belongsToShortsGroup() && !getPlayerTweaksData().isQuickSkipShortsAltEnabled()) {
+                (getVideo().belongsToShortsGroup() && !getPlayerTweaksData().isQuickSkipShortsAltEnabled()) ||
+                !getVideo().belongsToShortsGroup()) {
             return false;
         }
 
@@ -1099,3 +1100,4 @@ public class PlayerUIController extends BasePlayerController {
         ChannelPresenter.instance(getContext()).openChannel(getVideo());
     }
 }
+


### PR DESCRIPTION
It seems up/down accidentally skips normal video from the new shorts video, see: https://github.com/yuliskov/SmartTube/issues/5294

This extra check should prevent the up/down skip handler from acting on normal videos