### PR TITLE
feat: Audio time stretching

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/exoplayer/controller/ExoPlayerController.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/exoplayer/controller/ExoPlayerController.java
@@ -396,13 +396,12 @@ public class ExoPlayerController implements Player.EventListener {
     
     public void setPitch(float pitch) {
         if (mPlayer != null && pitch > 0 && !Helpers.floatEquals(pitch, getPitch())) {
-            float speed = pitch;
             if (PlayerTweaksData.instance(mContext).isAudioTimeStretchingEnabled()) {
-                speed = mPlayer.getPlaybackParameters().speed;
+                mPlayer.setPlaybackParameters(new PlaybackParameters(mPlayer.getPlaybackParameters().speed, pitch));
             } else {
                 MessageHelpers.showMessage(mContext, "Enable Audio time stretching from settings to independently control the pitch");
+                setSpeed(pitch);
             }
-            mPlayer.setPlaybackParameters(new PlaybackParameters(speed, pitch));
         }
     }
     


### PR DESCRIPTION
This PR is made to avoid audio distortions caused by changing the video speed.

Usually, time stretching is applied to the audio to maintain pitch, this causes audio distortions.
This adds a new user preference called `Audio time stretching` under `Player > misc` section, it is disabled by default. 

When disabled, the audio's playback rate is made to match the video's, effectively bypassing exoplayer's time stretching and its artifacts, also made sure the existing `Pitch Effect` feature also checks when trying to apply a custom pitch.

When enabled, the usual happens.

This is similar to NewPipe's `unhook` option.

Closes #4262, Closes #3177, Resolves #2754