### PR TITLE
Add `ignore-updates` flag to stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,8 +16,9 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         operations-per-run: 3000 # This may result in rate limiting, could we reduce and run in batches?
-        days-before-stale: 419 # 1st Jan 2025, as of 24th Feb 2026
+        days-before-stale: 420 # 1st Jan 2025, as of 25th Feb 2026
         days-before-close: 0
+        ignore-updates: true
         stale-issue-message: ''
         close-issue-message: | 
           **Due to a high volume of stale issues, all issues older than January 1st 2025 are being closed automatically.**


### PR DESCRIPTION
This PR adds the `ignore-updates` flag to the stale bot. This means it will use the creation date of an issue to determine if it is stale rather than recent activity.

If you have any old actions you are currently working on you don't want to be closed we could tag them and also add a `exempt-issue-labels` flag on the bot to skip them.