### PR TITLE
Add option to pause or stop after each video in queue

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/VideoLoaderController.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/VideoLoaderController.java
@@ -729,7 +729,7 @@ public class VideoLoaderController extends BasePlayerController {
             case PlayerConstants.PLAYBACK_MODE_CLOSE:
                 // Close player if suggestions not shown
                 // Except when playing from queue
-                if (mPlaylist.getNext() != null) {
+                if (mPlaylist.getNext() != null && !getPlayerTweaksData().isPauseOrStopAfterEachVideoInQueueEnabled()) {
                     loadNext();
                 } else {
                     AppDialogPresenter dialog = getAppDialogPresenter();
@@ -742,7 +742,7 @@ public class VideoLoaderController extends BasePlayerController {
             case PlayerConstants.PLAYBACK_MODE_PAUSE:
                 // Stop player after each video.
                 // Except when playing from queue
-                if (mPlaylist.getNext() != null) {
+                if (mPlaylist.getNext() != null && !getPlayerTweaksData().isPauseOrStopAfterEachVideoInQueueEnabled()) {
                     loadNext();
                 } else {
                     stopPlayback();

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/settings/PlayerSettingsPresenter.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/settings/PlayerSettingsPresenter.java
@@ -646,6 +646,10 @@ public class PlayerSettingsPresenter extends BasePresenter<Void> {
                 option -> mPlayerTweaksData.setRealChannelIconEnabled(option.isSelected()),
                 mPlayerTweaksData.isRealChannelIconEnabled()));
 
+        options.add(UiOptionItem.from(getContext().getString(R.string.pause_or_stop_after_each_video_in_queue),
+                option -> mPlayerTweaksData.setPauseOrStopAfterEachVideoInQueueEnabled(option.isSelected()),
+                mPlayerTweaksData.isPauseOrStopAfterEachVideoInQueueEnabled()));
+
         settingsPresenter.appendCheckedCategory(getContext().getString(R.string.player_other), options);
     }
 

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/prefs/PlayerTweaksData.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/prefs/PlayerTweaksData.java
@@ -108,6 +108,7 @@ public class PlayerTweaksData implements ProfileChangeListener {
     private boolean mIsNetworkErrorFixingDisabled;
     private boolean mIsDontResizeVideoToFitDialogEnabled;
     private boolean mIsSuggestionsHorizontallyScrolled;
+    private boolean mIsPauseOrStopAfterEachVideoInQueueEnabled;
     private final Runnable mPersistDataInt = this::persistDataInt;
 
     private PlayerTweaksData(Context context) {
@@ -681,6 +682,15 @@ public class PlayerTweaksData implements ProfileChangeListener {
         persistData();
     }
 
+    public boolean isPauseOrStopAfterEachVideoInQueueEnabled() {
+        return mIsPauseOrStopAfterEachVideoInQueueEnabled;
+    }
+
+    public void setPauseOrStopAfterEachVideoInQueueEnabled(boolean enable) {
+        mIsPauseOrStopAfterEachVideoInQueueEnabled = enable;
+        persistData();
+    }
+
     private void restoreData() {
         String data = mPrefs.getProfileData(VIDEO_PLAYER_TWEAKS_DATA);
 
@@ -751,6 +761,7 @@ public class PlayerTweaksData implements ProfileChangeListener {
         mIsQuickSkipShortsAltEnabled = Helpers.parseBoolean(split, 57, false);
         mIsQuickSkipVideosAltEnabled = Helpers.parseBoolean(split, 58, false);
         mIsAudioTimeStretchingEnabled = Helpers.parseBoolean(split, 59, true);
+        mIsPauseOrStopAfterEachVideoInQueueEnabled = Helpers.parseBoolean(split, 60, false);
 
         updateDefaultValues();
     }
@@ -778,7 +789,7 @@ public class PlayerTweaksData implements ProfileChangeListener {
                 mIsUnsafeAudioFormatsEnabled, null, mIsLoopShortsEnabled, mIsQuickSkipShortsEnabled, mIsRememberPositionOfLiveVideosEnabled,
                 mIsOculusQuestFixEnabled, null, mIsExtraLongSpeedListEnabled, mIsQuickSkipVideosEnabled, mIsNetworkErrorFixingDisabled, mIsCommentsPlacedLeft,
                 null, mIsAudioFocusEnabled, mIsDontResizeVideoToFitDialogEnabled, mIsSuggestionsHorizontallyScrolled,
-                mIsQuickSkipShortsAltEnabled, mIsQuickSkipVideosAltEnabled, mIsAudioTimeStretchingEnabled
+                mIsQuickSkipShortsAltEnabled, mIsQuickSkipVideosAltEnabled, mIsAudioTimeStretchingEnabled, mIsPauseOrStopAfterEachVideoInQueueEnabled
                 ));
     }
 

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -731,4 +731,5 @@
     <string name="msg_no_blocked_channels">No blocked channels</string>
     <string name="player_time_stretching">Audio time stretching</string>
     <string name="player_time_stretching_desc">Keeps voice natural when changing speed. May significantly reduce performance on some devices.</string>
+    <string name="pause_or_stop_after_each_video_in_queue">Override queue exception for pause &amp; stop after each video</string>
 </resources>


### PR DESCRIPTION
This PR adds a setting in Player -> Misc that allows playback to be paused  or stopped after each video in the playback queue when "**Pause playback after each video (except queue)** or **Stop playback after one video (except queue)**" is set in the player.

<img width="1506" height="849" alt="image" src="https://github.com/user-attachments/assets/29c2310a-d3df-4ca0-8d54-178b29660513" />
