### PR TITLE
Hide "Add to playback queue" option for videos already in the playback queue

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/dialogs/menu/VideoMenuPresenter.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/dialogs/menu/VideoMenuPresenter.java
@@ -710,6 +710,11 @@ public class VideoMenuPresenter extends BaseMenuPresenter {
 
         Playlist playlist = Playlist.instance();
 
+        // Toggle between add/remove while dialog is opened
+        if (playlist.contains(mVideo)) {
+            return;
+        }
+
         //List<Video> all = playlist.getAll();
         //
         //if (!all.isEmpty() && mVideo.equals(all.get(all.size() - 1))) {
@@ -746,9 +751,7 @@ public class VideoMenuPresenter extends BaseMenuPresenter {
         Playlist playlist = Playlist.instance();
         // Toggle between add/remove while dialog is opened
         //boolean containsVideo = playlist.containsAfterCurrent(mVideo);
-        boolean containsVideo = playlist.contains(mVideo);
-
-        if (!containsVideo) {
+        if (!playlist.contains(mVideo)) {
             return;
         }
 


### PR DESCRIPTION
This PR addresses https://github.com/yuliskov/SmartTube/issues/5464

It hides the **Add to playback queue** option when a video is long pressed if the video has already been added to the playback queue.