### PR TITLE
Improved QUIC support

### DIFF
--- a/exoplayer-amzn-2.10.6/extensions/cronet/src/main/java/com/google/android/exoplayer2/ext/cronet/CronetEngineWrapper.java
+++ b/exoplayer-amzn-2.10.6/extensions/cronet/src/main/java/com/google/android/exoplayer2/ext/cronet/CronetEngineWrapper.java
@@ -19,6 +19,7 @@ import android.content.Context;
 import androidx.annotation.IntDef;
 import com.google.android.exoplayer2.util.Log;
 import com.google.android.exoplayer2.util.Util;
+import java.io.File;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -102,15 +103,20 @@ public final class CronetEngineWrapper {
     // Sort remaining providers by type and version.
     CronetProviderComparator providerComparator = new CronetProviderComparator(preferGMSCoreCronet);
     Collections.sort(cronetProviders, providerComparator);
+    // Make cache dir for QUIC cache support
+    File cacheDir = new File(context.getCacheDir(), "StCronet");
+    cacheDir.mkdirs();
     for (int i = 0; i < cronetProviders.size() && cronetEngine == null; i++) {
       String providerName = cronetProviders.get(i).getName();
       try {
-        // MODIFIED: enable Quic
+        // MODIFIED: enable Quic and cache for Quic
         //cronetEngine = cronetProviders.get(i).createBuilder().build();
         cronetEngine = cronetProviders.get(i).createBuilder()
                 .enableQuic(true)
                 .enableHttp2(true)
                 .enableBrotli(true)
+                .setStoragePath(cacheDir.getAbsolutePath())
+                .enableHttpCache(CronetEngine.Builder.HTTP_CACHE_DISK_NO_HTTP, 2 * 1024 * 1024)
                 .build();
         if (providerComparator.isNativeProvider(providerName)) {
           cronetEngineSource = SOURCE_NATIVE;


### PR DESCRIPTION
QUIC can need cache in Cronet.
CronetEngine.Builder.HTTP_CACHE_DISK_NO_HTTP do not cache HTTP response data.
Maximum cache size is 2 MB.

Reference GoogleChromeLabs cronet-sample https://github.com/GoogleChromeLabs/cronet-sample/blob/50221f75d16bc948235f5a8f66c853af8770732c/android/app/src/main/java/com/google/samples/cronet_sample/CronetApplication.java#L67

> Enable on-disk cache, this enables automatic QUIC usage for subsequent requests to the same domain across application restarts.
> HTTP2 and QUIC support is enabled by default. When both are enabled (and no hints are provided), Cronet tries to use both protocols and it's nondeterministic which one will be used for the first few requests. As soon as Cronet is aware that a server supports QUIC, it will always attempt to use it first.