### PR TITLE
Fix Channel Up/Down like/dislike not persisting state

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/misc/PlayerKeyTranslator.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/misc/PlayerKeyTranslator.java
@@ -20,19 +20,15 @@ public class PlayerKeyTranslator extends GlobalKeyTranslator {
     private final Runnable likeAction = () -> {
         PlaybackPresenter playbackPresenter = getPlaybackPresenter();
         if (playbackPresenter != null && playbackPresenter.getView() != null) {
-            playbackPresenter.onButtonClicked(R.id.action_thumbs_up, PlayerUI.BUTTON_ON);
-            playbackPresenter.getView().setButtonState(R.id.action_thumbs_up, PlayerUI.BUTTON_ON);
-            playbackPresenter.getView().setButtonState(R.id.action_thumbs_down, PlayerUI.BUTTON_OFF);
-            MessageHelpers.showMessage(getContext(), R.string.action_like);
+            int currentState = playbackPresenter.getView().getButtonState(R.id.action_thumbs_up);
+            playbackPresenter.onButtonClicked(R.id.action_thumbs_up, currentState);
         }
     };
     private final Runnable dislikeAction = () -> {
         PlaybackPresenter playbackPresenter = getPlaybackPresenter();
         if (playbackPresenter != null && playbackPresenter.getView() != null) {
-            playbackPresenter.onButtonClicked(R.id.action_thumbs_down, PlayerUI.BUTTON_ON);
-            playbackPresenter.getView().setButtonState(R.id.action_thumbs_up, PlayerUI.BUTTON_OFF);
-            playbackPresenter.getView().setButtonState(R.id.action_thumbs_down, PlayerUI.BUTTON_ON);
-            MessageHelpers.showMessage(getContext(), R.string.action_dislike);
+            int currentState = playbackPresenter.getView().getButtonState(R.id.action_thumbs_down);
+            playbackPresenter.onButtonClicked(R.id.action_thumbs_down, currentState);
         }
     };
     private final Runnable speedUpAction = () -> speedUp(true);


### PR DESCRIPTION
## Problem

When using Channel Up/Down mapped to Like/Dislike, the visual icon shows as 
selected but the state is not actually saved. After exiting and returning 
to the player, the like/dislike is not persisted.

## Root Cause

The `likeAction` and `dislikeAction` always passed `PlayerUI.BUTTON_ON` to 
`onButtonClicked()`, regardless of the current button state. However, 
`onLikeClicked()` in `PlayerUIController` interprets the received state as 
the **current** state:

- If `BUTTON_ON` is received → assumes like is already active → calls `removeLikeObserve()`
- If `BUTTON_OFF` is received → assumes like is inactive → calls `setLikeObserve()`

This caused the API to always **remove** the like instead of adding it.

The visual state was manually forced in the action, masking the issue until 
the player was reloaded and the real server state was fetched.

## Solution

Read the actual button state via `getButtonState()` before calling 
`onButtonClicked()`, allowing the toggle logic in `PlayerUIController` 
to work correctly.

The manual `setButtonState()` and `showMessage()` calls are now removed 
as they are redundant - `onLikeClicked()`/`onDislikeClicked()` already 
handles updating the UI and showing feedback.