### PR TITLE
Fix thumbs up/down mutual exclusion

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/PlayerUIController.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/PlayerUIController.java
@@ -424,6 +424,7 @@ public class PlayerUIController extends BasePlayerController {
         boolean dislike = buttonState == PlayerUI.BUTTON_ON;
 
         getPlayer().setButtonState(R.id.action_thumbs_down, !dislike ? PlayerUI.BUTTON_ON : PlayerUI.BUTTON_OFF);
+        getPlayer().setButtonState(R.id.action_thumbs_up, PlayerUI.BUTTON_OFF);
 
         if (!mIsMetadataLoaded) {
             MessageHelpers.showMessage(getContext(), R.string.wait_data_loading);
@@ -451,6 +452,7 @@ public class PlayerUIController extends BasePlayerController {
         boolean like = buttonState == PlayerUI.BUTTON_ON;
 
         getPlayer().setButtonState(R.id.action_thumbs_up, !like ? PlayerUI.BUTTON_ON : PlayerUI.BUTTON_OFF);
+        getPlayer().setButtonState(R.id.action_thumbs_down, PlayerUI.BUTTON_OFF);
 
         if (!mIsMetadataLoaded) {
             MessageHelpers.showMessage(getContext(), R.string.wait_data_loading);


### PR DESCRIPTION
When clicking like, ensure dislike is turned off and vice-versa.
Prevents both buttons being ON at the same time.

<img width="268" height="143" alt="screenshot" src="https://github.com/user-attachments/assets/9e67ccc6-010d-4c0b-83a4-066daf611a44" />