### PR TITLE
Configurable auto-like trigger (TV-friendly)

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/settings/PlayerSettingsPresenter.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/settings/PlayerSettingsPresenter.java
@@ -77,10 +77,66 @@ public class PlayerSettingsPresenter extends BasePresenter<Void> {
         appendPixelRatioCategory(settingsPresenter);
         //appendPlayerExitCategory(settingsPresenter);
         appendSleepTimerCategory(settingsPresenter);
+        appendAutoLikeCategory(settingsPresenter);
         appendMiscCategory(settingsPresenter);
         appendDeveloperCategory(settingsPresenter);
 
         settingsPresenter.showDialog(getContext().getString(R.string.settings_player), mOnFinish);
+    }
+
+    private void appendAutoLikeCategory(AppDialogPresenter settingsPresenter) {
+        settingsPresenter.appendSingleButton(UiOptionItem.from(getContext().getString(R.string.player_autolike), optionItem -> {
+            AppDialogPresenter presenter = AppDialogPresenter.instance(getContext());
+
+            List<OptionItem> triggerOptions = new ArrayList<>();
+            boolean enabled = mPlayerTweaksData.isAutoLikeEnabled();
+            int mode = mPlayerTweaksData.getAutoLikeMode();
+            int value = mPlayerTweaksData.getAutoLikeValue();
+
+            triggerOptions.add(UiOptionItem.from(
+                    getContext().getString(R.string.option_disabled),
+                    option -> mPlayerTweaksData.setAutoLikeEnabled(false),
+                    !enabled));
+
+            for (int minutes : new int[] {1, 2, 3, 5, 10, 15}) {
+                int seconds = minutes * 60;
+                triggerOptions.add(UiOptionItem.from(
+                        minutes + " min",
+                        option -> {
+                            mPlayerTweaksData.setAutoLikeEnabled(true);
+                            mPlayerTweaksData.setAutoLikeMode(PlayerTweaksData.AUTOLIKE_MODE_SECONDS);
+                            mPlayerTweaksData.setAutoLikeValue(seconds);
+                        },
+                        enabled && mode == PlayerTweaksData.AUTOLIKE_MODE_SECONDS && value == seconds));
+            }
+
+            for (int percent : new int[] {25, 50, 75}) {
+                triggerOptions.add(UiOptionItem.from(
+                        percent + "%",
+                        option -> {
+                            mPlayerTweaksData.setAutoLikeEnabled(true);
+                            mPlayerTweaksData.setAutoLikeMode(PlayerTweaksData.AUTOLIKE_MODE_PERCENT);
+                            mPlayerTweaksData.setAutoLikeValue(percent);
+                        },
+                        enabled && mode == PlayerTweaksData.AUTOLIKE_MODE_PERCENT && value == percent));
+            }
+
+            presenter.appendRadioCategory(getContext().getString(R.string.player_autolike_mode), triggerOptions);
+
+            // Minimum duration (minutes -> seconds)
+            List<OptionItem> minDurOptions = new ArrayList<>();
+            int currentMinDur = mPlayerTweaksData.getAutoLikeMinDurationSec();
+            for (int minutes : new int[] {1, 3, 5, 10, 15, 30}) {
+                int seconds = minutes * 60;
+                minDurOptions.add(UiOptionItem.from(
+                        minutes + " min",
+                        option -> mPlayerTweaksData.setAutoLikeMinDurationSec(seconds),
+                        currentMinDur == seconds));
+            }
+            presenter.appendRadioCategory(getContext().getString(R.string.player_autolike_min_duration), minDurOptions);
+
+            presenter.showDialog(getContext().getString(R.string.player_autolike));
+        }));
     }
 
     private void appendOKButtonCategory(AppDialogPresenter settingsPresenter) {

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/prefs/PlayerTweaksData.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/prefs/PlayerTweaksData.java
@@ -11,6 +11,8 @@ import com.liskovsoft.youtubeapi.service.internal.MediaServiceData;
 
 public class PlayerTweaksData implements ProfileChangeListener {
     private static final String VIDEO_PLAYER_TWEAKS_DATA = "video_player_tweaks_data";
+    public static final int AUTOLIKE_MODE_SECONDS = 0;
+    public static final int AUTOLIKE_MODE_PERCENT = 1;
     public static final int PLAYER_DATA_SOURCE_DEFAULT = 0;
     public static final int PLAYER_DATA_SOURCE_OKHTTP = 1;
     public static final int PLAYER_DATA_SOURCE_CRONET = 2;
@@ -109,6 +111,10 @@ public class PlayerTweaksData implements ProfileChangeListener {
     private boolean mIsDontResizeVideoToFitDialogEnabled;
     private boolean mIsSuggestionsHorizontallyScrolled;
     private boolean mIsQueueRespectsPlaybackMode;
+    private boolean mIsAutoLikeEnabled;
+    private int mAutoLikeMode;
+    private int mAutoLikeValue;
+    private int mAutoLikeMinDurationSec;
     private final Runnable mPersistDataInt = this::persistDataInt;
 
     private PlayerTweaksData(Context context) {
@@ -691,6 +697,46 @@ public class PlayerTweaksData implements ProfileChangeListener {
         persistData();
     }
 
+    public boolean isAutoLikeEnabled() {
+        return mIsAutoLikeEnabled;
+    }
+
+    public void setAutoLikeEnabled(boolean enable) {
+        mIsAutoLikeEnabled = enable;
+        persistData();
+    }
+
+    public int getAutoLikeMode() {
+        return mAutoLikeMode;
+    }
+
+    public void setAutoLikeMode(int mode) {
+        mAutoLikeMode = mode;
+        persistData();
+    }
+
+    /**
+     * When {@link #AUTOLIKE_MODE_SECONDS}: value is seconds.\n
+     * When {@link #AUTOLIKE_MODE_PERCENT}: value is percent (1..99).
+     */
+    public int getAutoLikeValue() {
+        return mAutoLikeValue;
+    }
+
+    public void setAutoLikeValue(int value) {
+        mAutoLikeValue = value;
+        persistData();
+    }
+
+    public int getAutoLikeMinDurationSec() {
+        return mAutoLikeMinDurationSec;
+    }
+
+    public void setAutoLikeMinDurationSec(int minDurationSec) {
+        mAutoLikeMinDurationSec = minDurationSec;
+        persistData();
+    }
+
     private void restoreData() {
         String data = mPrefs.getProfileData(VIDEO_PLAYER_TWEAKS_DATA);
 
@@ -762,6 +808,10 @@ public class PlayerTweaksData implements ProfileChangeListener {
         mIsQuickSkipVideosAltEnabled = Helpers.parseBoolean(split, 58, false);
         mIsAudioTimeStretchingEnabled = Helpers.parseBoolean(split, 59, true);
         mIsQueueRespectsPlaybackMode = Helpers.parseBoolean(split, 60, false);
+        mIsAutoLikeEnabled = Helpers.parseBoolean(split, 61, false);
+        mAutoLikeMode = Helpers.parseInt(split, 62, AUTOLIKE_MODE_SECONDS);
+        mAutoLikeValue = Helpers.parseInt(split, 63, 60);
+        mAutoLikeMinDurationSec = Helpers.parseInt(split, 64, 180);
 
         updateDefaultValues();
     }
@@ -789,7 +839,8 @@ public class PlayerTweaksData implements ProfileChangeListener {
                 mIsUnsafeAudioFormatsEnabled, null, mIsLoopShortsEnabled, mIsQuickSkipShortsEnabled, mIsRememberPositionOfLiveVideosEnabled,
                 mIsOculusQuestFixEnabled, null, mIsExtraLongSpeedListEnabled, mIsQuickSkipVideosEnabled, mIsNetworkErrorFixingDisabled, mIsCommentsPlacedLeft,
                 null, mIsAudioFocusEnabled, mIsDontResizeVideoToFitDialogEnabled, mIsSuggestionsHorizontallyScrolled,
-                mIsQuickSkipShortsAltEnabled, mIsQuickSkipVideosAltEnabled, mIsAudioTimeStretchingEnabled, mIsQueueRespectsPlaybackMode
+                mIsQuickSkipShortsAltEnabled, mIsQuickSkipVideosAltEnabled, mIsAudioTimeStretchingEnabled, mIsQueueRespectsPlaybackMode,
+                mIsAutoLikeEnabled, mAutoLikeMode, mAutoLikeValue, mAutoLikeMinDurationSec
                 ));
     }
 

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -102,6 +102,14 @@
     <string name="check_updates_auto">Notify about updates</string>
     <string name="select_account_on_boot">Show account selection on boot</string>
     <string name="player_other">Misc</string>
+    <string name="player_autolike">Auto-like</string>
+    <string name="player_autolike_enable">Enable auto-like</string>
+    <string name="player_autolike_mode">Auto-like trigger</string>
+    <string name="player_autolike_mode_seconds">After N seconds</string>
+    <string name="player_autolike_mode_percent">After N% watched</string>
+    <string name="player_autolike_value_seconds">After (minutes)</string>
+    <string name="player_autolike_value_percent">After (% watched)</string>
+    <string name="player_autolike_min_duration">Minimum video length (minutes)</string>
     <string name="player_full_date">Precise date in description</string>
     <string name="open_channel">Open channel</string>
     <string name="open_playlist">Open playlist</string>

--- a/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/tv/ui/playback/PlaybackFragment.java
+++ b/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/tv/ui/playback/PlaybackFragment.java
@@ -3,6 +3,8 @@ package com.liskovsoft.smartyoutubetv2.tv.ui.playback;
 import android.media.session.PlaybackState;
 import android.os.Build.VERSION;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.support.v4.media.MediaMetadataCompat;
 import android.support.v4.media.session.MediaSessionCompat;
 import android.support.v4.media.session.PlaybackStateCompat;
@@ -12,6 +14,7 @@ import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -100,6 +103,7 @@ public class PlaybackFragment extends SeekModePlaybackFragment implements Playba
     private static final String TAG = PlaybackFragment.class.getSimpleName();
     private static final String SELECTED_VIDEO_ID = "SelectedVideoId";
     private static final int UPDATE_DELAY_MS = 100;
+    private static final int WATCH_OVERLAY_UPDATE_INTERVAL_MS = 1_000;
     private static final int SUGGESTIONS_START_INDEX = 1;
     private VideoPlayerGlue mPlayerGlue;
     private SimpleExoPlayer mPlayer;
@@ -124,6 +128,29 @@ public class PlaybackFragment extends SeekModePlaybackFragment implements Playba
     private Boolean mIsControlsShownPreviously;
     private Video mPendingFocus;
     private String mSelectedVideoId;
+    private PlayerTweaksData mPlayerTweaksData;
+
+    private View mWatchOverlayBackground;
+    private TextView mWatchOverlayMessage;
+    private boolean mHasAutoLikedCurrentVideo;
+
+    private final Handler mWatchOverlayHandler = new Handler(Looper.getMainLooper());
+    private final Runnable mWatchOverlayRunnable = new Runnable() {
+        @Override
+        public void run() {
+            long durationMs = getDurationMs();
+            if (durationMs > 0) {
+                checkWatchOverlayTriggers(getPositionMs(), durationMs);
+            }
+            mWatchOverlayHandler.postDelayed(this, WATCH_OVERLAY_UPDATE_INTERVAL_MS);
+        }
+    };
+    private final Runnable mHideWatchOverlayRunnable = new Runnable() {
+        @Override
+        public void run() {
+            hideWatchOverlay();
+        }
+    };
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -138,6 +165,7 @@ public class PlaybackFragment extends SeekModePlaybackFragment implements Playba
         mPlaybackPresenter = PlaybackPresenter.instance(getContext());
         mPlaybackPresenter.setView(this);
         mExoPlayerController = new ExoPlayerController(getContext(), mPlaybackPresenter);
+        mPlayerTweaksData = PlayerTweaksData.instance(getContext());
 
         // Fix open previous video
         if (mPlaybackPresenter.getVideo() != null) {
@@ -166,6 +194,12 @@ public class PlaybackFragment extends SeekModePlaybackFragment implements Playba
         // We should use internal progress manager because it's used in many places like Exo engine etc.
         // ProgressBar.setRootView already called at this moment.
         ProgressBarManager.setup(getProgressBarManager(), (ViewGroup) root);
+
+        mWatchOverlayBackground = root.findViewById(R.id.watch_overlay_background);
+        View messageView = root.findViewById(R.id.watch_overlay_message);
+        mWatchOverlayMessage = messageView instanceof TextView ? (TextView) messageView : null;
+        resetWatchOverlayState();
+        hideWatchOverlay();
 
         return root;
     }
@@ -231,6 +265,8 @@ public class PlaybackFragment extends SeekModePlaybackFragment implements Playba
         showHideWidgets(true); // PIP mode fix
         blockEngine(false); // reset bg mode
         //ExoPlayerInitializer.enableAudioFocus(mPlayer, true); // Restore focus after PIP
+
+        startWatchOverlayUpdates();
     }
 
     @Override
@@ -246,6 +282,8 @@ public class PlaybackFragment extends SeekModePlaybackFragment implements Playba
 
         showHideWidgets(false); // PIP mode fix
         //ExoPlayerInitializer.enableAudioFocus(mPlayer, false); // Disable focus in PIP
+
+        stopWatchOverlayUpdates();
     }
 
     public void onDispatchKeyEvent(KeyEvent event) {
@@ -820,12 +858,100 @@ public class PlaybackFragment extends SeekModePlaybackFragment implements Playba
     public void setVideo(Video video) {
         mExoPlayerController.setVideo(video);
 
+        resetWatchOverlayState();
+        hideWatchOverlay();
+
         if (mPlayerGlue != null && video != null) {
             // Preserve player formatting
             mPlayerGlue.setTitle(video.getTitleFull() != null ? video.getTitleFull() : "...");
             mPlayerGlue.setSubtitle(video.getSecondTitleFull() != null ? createSubtitle(video) : "...");
             mPlayerGlue.setVideo(video);
         }
+    }
+
+    private void resetWatchOverlayState() {
+        mHasAutoLikedCurrentVideo = false;
+    }
+
+    private void showWatchOverlay(String message) {
+        if (mWatchOverlayBackground == null || mWatchOverlayMessage == null) {
+            return;
+        }
+
+        mWatchOverlayMessage.setText(message);
+        mWatchOverlayBackground.setVisibility(View.VISIBLE);
+        mWatchOverlayMessage.setVisibility(View.VISIBLE);
+
+        mWatchOverlayHandler.removeCallbacks(mHideWatchOverlayRunnable);
+        mWatchOverlayHandler.postDelayed(mHideWatchOverlayRunnable, 5_000L);
+    }
+
+    private void hideWatchOverlay() {
+        if (mWatchOverlayBackground != null) {
+            mWatchOverlayBackground.setVisibility(View.GONE);
+        }
+        if (mWatchOverlayMessage != null) {
+            mWatchOverlayMessage.setVisibility(View.GONE);
+        }
+        mWatchOverlayHandler.removeCallbacks(mHideWatchOverlayRunnable);
+    }
+
+    private void ensureCurrentVideoLiked() {
+        if (mPlayerGlue == null || mPlaybackPresenter == null) {
+            return;
+        }
+
+        int currentState = mPlayerGlue.getButtonState(R.id.action_thumbs_up);
+        if (currentState == PlayerUI.BUTTON_OFF) {
+            mPlaybackPresenter.onButtonClicked(R.id.action_thumbs_up, currentState);
+        }
+    }
+
+    private void maybeAutoLikeCurrentVideo() {
+        if (!mHasAutoLikedCurrentVideo) {
+            ensureCurrentVideoLiked();
+            mHasAutoLikedCurrentVideo = true;
+        }
+    }
+
+    private void checkWatchOverlayTriggers(long currentPositionMs, long durationMs) {
+        if (mPlayerTweaksData == null || !mPlayerTweaksData.isAutoLikeEnabled() || mHasAutoLikedCurrentVideo) {
+            return;
+        }
+
+        long minDurationMs = Math.max(0, mPlayerTweaksData.getAutoLikeMinDurationSec()) * 1_000L;
+        if (durationMs < minDurationMs) {
+            return;
+        }
+
+        long thresholdMs;
+        if (mPlayerTweaksData.getAutoLikeMode() == PlayerTweaksData.AUTOLIKE_MODE_PERCENT) {
+            int percent = mPlayerTweaksData.getAutoLikeValue();
+            percent = Math.max(1, Math.min(99, percent));
+            thresholdMs = (long) (durationMs * (percent / 100.0));
+        } else {
+            int seconds = mPlayerTweaksData.getAutoLikeValue();
+            seconds = Math.max(0, seconds);
+            thresholdMs = seconds * 1_000L;
+        }
+
+        if (currentPositionMs >= thresholdMs) {
+            boolean willLike = mPlayerGlue != null && mPlayerGlue.getButtonState(R.id.action_thumbs_up) == PlayerUI.BUTTON_OFF;
+            maybeAutoLikeCurrentVideo();
+            showWatchOverlay(willLike
+                    ? "AutoLike: Video wurde geliked."
+                    : "AutoLike: Video ist bereits geliked.");
+        }
+    }
+
+    private void startWatchOverlayUpdates() {
+        mWatchOverlayHandler.removeCallbacks(mWatchOverlayRunnable);
+        mWatchOverlayHandler.post(mWatchOverlayRunnable);
+    }
+
+    private void stopWatchOverlayUpdates() {
+        mWatchOverlayHandler.removeCallbacks(mWatchOverlayRunnable);
+        hideWatchOverlay();
     }
 
     @Override

--- a/smarttubetv/src/main/res/layout/lb_playback_fragment.xml
+++ b/smarttubetv/src/main/res/layout/lb_playback_fragment.xml
@@ -31,6 +31,27 @@
         android:paddingLeft="150sp"
         android:paddingRight="150sp"/>
 
+    <View
+        android:id="@+id/watch_overlay_background"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top"
+        android:background="#66000000"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/watch_overlay_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top"
+        android:padding="16dp"
+        android:gravity="center"
+        android:textColor="@color/white"
+        android:textSize="18sp"
+        android:shadowColor="@color/black"
+        android:shadowRadius="1.6"
+        android:visibility="gone" />
+
     <LinearLayout
         android:id="@+id/live_chat_wrapper"
         android:layout_width="300sp"


### PR DESCRIPTION
## Summary\n- Add configurable auto-like feature with TV-friendly settings (no keyboard input).\n- Trigger can be minutes or percent; minimum video length selectable.\n- Overlay is less intrusive and indicates whether auto-like was applied.\n\n## Notes\n- This PR does **not** change the Android package/applicationId.\n\n## Test plan\n- Build: ssembleStstableDebug\n- On device: Player → Auto-like, select trigger and min length; verify like happens once when threshold reached.