### PR TITLE
improve: Unlocalised Video Titles

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/SuggestionsController.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/SuggestionsController.java
@@ -29,6 +29,8 @@ import com.liskovsoft.smartyoutubetv2.common.app.presenters.PlaybackPresenter;
 import com.liskovsoft.smartyoutubetv2.common.misc.BrowseProcessorManager;
 import com.liskovsoft.smartyoutubetv2.common.misc.MediaServiceManager;
 import com.liskovsoft.smartyoutubetv2.common.prefs.GeneralData;
+import com.liskovsoft.smartyoutubetv2.common.prefs.MainUIData;
+import com.liskovsoft.smartyoutubetv2.common.prefs.UnlocalizedTitleData;
 import com.liskovsoft.smartyoutubetv2.common.utils.Utils;
 import com.liskovsoft.youtubeapi.service.YouTubeServiceManager;
 import io.reactivex.Observable;
@@ -43,6 +45,8 @@ public class SuggestionsController extends BasePlayerController {
     private MediaItemService mMediaItemService;
     private ContentService mContentService;
     private BrowseProcessorManager mBrowseProcessor;
+    private MainUIData mMainUIData;
+    private UnlocalizedTitleData mTitleCache;
     private Video mNextSectionVideo;
     private int mFocusCount;
     private int mNextRetryCount;
@@ -64,6 +68,8 @@ public class SuggestionsController extends BasePlayerController {
         mBrowseProcessor = new BrowseProcessorManager(getContext(), PlaybackPresenter.instance(getContext())::syncItem);
         mMediaItemService = YouTubeServiceManager.instance().getMediaItemService();
         mContentService = YouTubeServiceManager.instance().getContentService();
+        mMainUIData = MainUIData.instance(getContext());
+        mTitleCache = UnlocalizedTitleData.instance(getContext());
     }
 
     @Override
@@ -225,11 +231,41 @@ public class SuggestionsController extends BasePlayerController {
         }
 
         video.sync(mediaItemMetadata);
+        resolveUnlocalizedTitle(video);
         getPlayer().setVideo(video);
 
         getPlayer().setNextTitle(getNext());
 
         appendDislikes(video);
+    }
+
+    private void resolveUnlocalizedTitle(Video video) {
+        if (!mMainUIData.isUnlocalizedTitlesEnabled() || video == null || video.videoId == null) {
+            return;
+        }
+
+        // Already resolved (e.g. from browse card processor)
+        if (video.deArrowTitle != null) {
+            return;
+        }
+
+        // Check persistent cache
+        String cachedTitle = mTitleCache.getTitle(video.videoId);
+        if (cachedTitle != null) {
+            video.deArrowTitle = cachedTitle;
+            return;
+        }
+
+        // Cache miss — fetch asynchronously, refresh player title on arrival
+        Disposable action = mMediaItemService.getUnlocalizedTitleObserve(video.videoId)
+                .subscribe(title -> {
+                    mTitleCache.putTitle(video.videoId, title);
+                    video.deArrowTitle = title;
+                    if (getPlayer() != null && !Helpers.equals(video.title, title)) {
+                        getPlayer().setVideo(video);
+                    }
+                }, error -> Log.d(TAG, "Unlocalized title: fetch failed for player video"));
+        mActions.add(action);
     }
 
     public void loadSuggestions(Video video) {

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/misc/UnlocalizedTitleProcessor.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/misc/UnlocalizedTitleProcessor.java
@@ -11,6 +11,7 @@ import com.liskovsoft.sharedutils.rx.RxHelper;
 import com.liskovsoft.smartyoutubetv2.common.app.models.data.Video;
 import com.liskovsoft.smartyoutubetv2.common.app.models.data.VideoGroup;
 import com.liskovsoft.smartyoutubetv2.common.prefs.MainUIData;
+import com.liskovsoft.smartyoutubetv2.common.prefs.UnlocalizedTitleData;
 import com.liskovsoft.smartyoutubetv2.common.prefs.common.DataChangeBase.OnDataChange;
 import com.liskovsoft.youtubeapi.service.YouTubeServiceManager;
 
@@ -22,9 +23,11 @@ import io.reactivex.disposables.Disposable;
 
 public class UnlocalizedTitleProcessor implements OnDataChange, BrowseProcessor {
     private static final String TAG = UnlocalizedTitleProcessor.class.getSimpleName();
+    private static final int CONCURRENT_REQUESTS = 5;
     private final OnItemReady mOnItemReady;
     private final MediaItemService mItemService;
     private final MainUIData mMainUIData;
+    private final UnlocalizedTitleData mTitleCache;
     private boolean mIsUnlocalizedTitlesEnabled;
     private Disposable mResult;
 
@@ -33,6 +36,7 @@ public class UnlocalizedTitleProcessor implements OnDataChange, BrowseProcessor 
         ServiceManager service = YouTubeServiceManager.instance();
         mItemService = service.getMediaItemService();
         mMainUIData = MainUIData.instance(context);
+        mTitleCache = UnlocalizedTitleData.instance(context);
         mMainUIData.setOnChange(this);
         initData();
     }
@@ -52,41 +56,54 @@ public class UnlocalizedTitleProcessor implements OnDataChange, BrowseProcessor 
             return;
         }
 
-        List<String> videoIds = getVideoIds(videoGroup);
-        mResult = Observable.fromIterable(videoIds)
-                .flatMap(videoId -> mItemService.getUnlocalizedTitleObserve(videoId)
-                        .map(newTitle -> new Pair<>(videoId, newTitle)))
-                .subscribe(title -> {
-                    Video video = videoGroup.findVideoById(title.first);
-                    if (video == null) {
-                        return;
-                    }
-                    video.deArrowTitle = title.second; // sometimes player titles localized while cards not
-                    if (!Helpers.equals(video.title, video.deArrowTitle)) {
-                        mOnItemReady.onItemReady(video);
-                    }
-                },
-                error -> {
-                    Log.d(TAG, "Unlocalized title: Cannot process the video");
-                });
-    }
-
-    @Override
-    public void dispose() {
-        RxHelper.disposeActions(mResult);
-    }
-
-    private List<String> getVideoIds(VideoGroup videoGroup) {
-        List<String> result = new ArrayList<>();
+        List<String> videoIds = new ArrayList<>();
 
         for (Video video : videoGroup.getVideos()) {
             if (video.deArrowProcessed) {
                 continue;
             }
             video.deArrowProcessed = true;
-            result.add(video.videoId);
+
+            // Check cache first — apply immediately if hit
+            String cachedTitle = mTitleCache.getTitle(video.videoId);
+            if (cachedTitle != null) {
+                video.deArrowTitle = cachedTitle;
+                if (!Helpers.equals(video.title, video.deArrowTitle)) {
+                    mOnItemReady.onItemReady(video);
+                }
+            } else {
+                videoIds.add(video.videoId);
+            }
         }
 
-        return result;
+        // Only fetch titles we don't have cached
+        if (videoIds.isEmpty()) {
+            return;
+        }
+
+        mResult = Observable.fromIterable(videoIds)
+                .flatMap(videoId -> mItemService.getUnlocalizedTitleObserve(videoId)
+                        .map(newTitle -> new Pair<>(videoId, newTitle)), CONCURRENT_REQUESTS)
+                .subscribe(title -> {
+                    // Store in cache
+                    mTitleCache.putTitle(title.first, title.second);
+
+                    Video video = videoGroup.findVideoById(title.first);
+                    if (video == null) {
+                        return;
+                    }
+                    video.deArrowTitle = title.second;
+                    if (!Helpers.equals(video.title, video.deArrowTitle)) {
+                        mOnItemReady.onItemReady(video);
+                    }
+                },
+                        error -> {
+                            Log.d(TAG, "Unlocalized title: Cannot process the video");
+                        });
+    }
+
+    @Override
+    public void dispose() {
+        RxHelper.disposeActions(mResult);
     }
 }

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/prefs/UnlocalizedTitleData.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/prefs/UnlocalizedTitleData.java
@@ -1,0 +1,99 @@
+package com.liskovsoft.smartyoutubetv2.common.prefs;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+
+import com.liskovsoft.sharedutils.helpers.Helpers;
+import com.liskovsoft.smartyoutubetv2.common.utils.Utils;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class UnlocalizedTitleData {
+    private static final String UNLOCALIZED_TITLE_DATA = "unlocalized_title_data";
+    private static final int MAX_ENTRIES = 5000;
+    @SuppressLint("StaticFieldLeak")
+    private static UnlocalizedTitleData sInstance;
+    private final AppPrefs mPrefs;
+    private LinkedHashMap<String, String> mTitleCache; // videoId -> original title
+    private final Runnable mPersistStateInt = this::persistStateInt;
+    private boolean mIsDirty;
+
+    private UnlocalizedTitleData(Context context) {
+        mPrefs = AppPrefs.instance(context);
+        restoreState();
+    }
+
+    public static UnlocalizedTitleData instance(Context context) {
+        if (sInstance == null) {
+            sInstance = new UnlocalizedTitleData(context.getApplicationContext());
+        }
+
+        return sInstance;
+    }
+
+    /**
+     * Get a cached original title for the given video ID.
+     * @return the original title, or null if not cached
+     */
+    public String getTitle(String videoId) {
+        if (videoId == null || mTitleCache == null) {
+            return null;
+        }
+
+        return mTitleCache.get(videoId);
+    }
+
+    /**
+     * Cache an original title for the given video ID.
+     * Evicts oldest entries (FIFO) when the cache exceeds MAX_ENTRIES.
+     */
+    public void putTitle(String videoId, String title) {
+        if (videoId == null || title == null) {
+            return;
+        }
+
+        mTitleCache.put(videoId, title);
+
+        // FIFO eviction: remove oldest entries when exceeding limit
+        while (mTitleCache.size() > MAX_ENTRIES) {
+            String oldestKey = mTitleCache.keySet().iterator().next();
+            mTitleCache.remove(oldestKey);
+        }
+
+        mIsDirty = true;
+        persistState();
+    }
+
+    private synchronized void restoreState() {
+        String data = mPrefs.getData(UNLOCALIZED_TITLE_DATA);
+
+        mTitleCache = new LinkedHashMap<>();
+
+        Map<String, String> parsed = Helpers.parseMap(data, Helpers::parseStr, Helpers::parseStr);
+
+        if (!parsed.isEmpty()) {
+            mTitleCache.putAll(parsed);
+        }
+    }
+
+    private void persistState() {
+        Utils.postDelayed(mPersistStateInt, 10_000);
+    }
+
+    private void persistStateInt() {
+        if (!mIsDirty) {
+            return;
+        }
+
+        mPrefs.setData(UNLOCALIZED_TITLE_DATA, Helpers.mergeMap(mTitleCache));
+        mIsDirty = false;
+    }
+
+    /**
+     * Force immediate persistence (e.g. before app exit).
+     */
+    public void persistNow() {
+        Utils.post(mPersistStateInt);
+    }
+}


### PR DESCRIPTION
## Problem

The "Unlocalised video titles" feature fires a **separate HTTP request** (to YouTube's oEmbed endpoint) for **every video card** on screen. A typical Home screen with ~50 videos triggers ~50 individual network requests — on every visit, with no caching across sessions.

Additionally, the player title bar was **not covered** by the feature. Videos entering the player via deep links, casting, or remote control would display YouTube's auto-translated `metadataTitle` instead of the original.

## Changes

### 1. Persistent title cache (`UnlocalizedTitleData`)

- **New class**: `UnlocalizedTitleData` — SharedPreferences-backed FIFO cache (5,000 entries) mapping `videoId → original title`.
- Original titles are immutable, so the cache needs no TTL or invalidation.
- Uses established codebase patterns: `Helpers.mergeMap`/`parseMap` for serialisation, `Utils.postDelayed` (10s debounce) for disk writes.
- After the first browsing session, most titles are served from cache with **zero network cost**.

### 2. Cache-first processor (`UnlocalizedTitleProcessor`)

- On each `VideoGroup`, the processor now checks the cache before queueing an oEmbed request.
- Cache hits are applied **synchronously** — no network call, no async delay.
- Cache misses are fetched and cached on arrival for future sessions.

### 3. Player title coverage (`SuggestionsController`)

- After `video.sync(metadata)` sets the (potentially translated) `metadataTitle`, `resolveUnlocalizedTitle()` now runs:
  - If `deArrowTitle` is already set (from browse card) → no-op.
  - Cache hit → applied synchronously before `setVideo`.
  - Cache miss → single async oEmbed fetch; player title refreshes on arrival.
- Covers deep links, casting, and remote control scenarios.

## Files Changed

| File | Change |
|---|---|
| `UnlocalizedTitleData.java` | **New** — persistent FIFO cache |
| `UnlocalizedTitleProcessor.java` | **Modified** — cache-first lookup |
| `SuggestionsController.java` | **Modified** — player title resolution |
