### PR TITLE
Fix account picker showing two filled radio buttons

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/dialogs/AccountSelectionPresenter.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/dialogs/AccountSelectionPresenter.java
@@ -85,11 +85,13 @@ public class AccountSelectionPresenter extends BasePresenter<Void> {
     private void appendAccountSelection(List<Account> accounts, List<Drawable> icons, AppDialogPresenter settingsPresenter) {
         List<OptionItem> optionItems = new ArrayList<>();
 
+        // "None" is selected only when no account is currently selected — otherwise the
+        // radio category renders two filled buttons (None + the active account).
         optionItems.add(UiOptionItem.from(
                 getContext().getString(R.string.dialog_account_none), optionItem -> {
                     selectAccount(null);
                     settingsPresenter.closeDialog();
-                }, true
+                }, mSignInService.getSelectedAccount() == null
         ));
 
         int index = -1;

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/settings/AccountSettingsPresenter.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/settings/AccountSettingsPresenter.java
@@ -86,11 +86,13 @@ public class AccountSettingsPresenter extends BasePresenter<Void> {
 
         List<OptionItem> optionItems = new ArrayList<>();
 
+        // "None" is selected only when no account is currently selected — otherwise the
+        // radio category renders two filled buttons (None + the active account).
         optionItems.add(UiOptionItem.from(
                 getContext().getString(R.string.dialog_account_none), optionItem -> {
                     AccountSelectionPresenter.instance(getContext()).selectAccount(null);
                     settingsPresenter.closeDialog();
-                }, true
+                }, getSignInService().getSelectedAccount() == null
         ));
 
         CharSequence accountName = " (" + getContext().getString(R.string.dialog_account_none) + ")";


### PR DESCRIPTION
## Summary

The account picker (`AccountSelectionPresenter`) and the Accounts settings dialog (`AccountSettingsPresenter`) both render with **two filled radio buttons** when an account is signed in: the hard-coded `None` entry plus the currently-selected account.

The cause is the same in both files: `None` is added to the radio category with `isSelected = true` hard-coded, while the account loop below also marks the active account as selected. `appendRadioCategory` then renders both as filled.

## Fix

Mark `None` as selected only when no account is currently selected:

\`\`\`java
}, mSignInService.getSelectedAccount() == null
\`\`\`

Two-line change in two files. No behaviour change when zero accounts are signed in (still `None` selected); fixes the visual when one or more accounts are signed in.

## Repro

1. Sign in to one or more accounts.
2. Open Settings → Accounts (or trigger Select-Account-on-Boot).
3. Before: `None` and the active account both render as filled.
4. After: only the active account renders as filled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)