### PR TITLE
ci: locks versions of actions using hashes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: recursive
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -48,7 +48,7 @@ jobs:
         run: ./gradlew lintStbetaRelease
 
       - name: Upload Lint Report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: lint-report
@@ -61,7 +61,7 @@ jobs:
       - name: VirusTotal Scan
         if: ${{ env.HAS_VT_KEY == 'true' }}
         id: vt
-        uses: crazy-max/ghaction-virustotal@v5
+        uses: crazy-max/ghaction-virustotal@936d8c5c00afe97d3d9a1af26d017cfdf26800a2 # v5.0.0
         with:
           vt_api_key: ${{ secrets.VIRUS_TOTAL_API_KEY }}
           files: |
@@ -90,28 +90,28 @@ jobs:
           done
 
       - name: Upload ARM64 APK
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SmartTube_${{ steps.get_version.outputs.VERSION_NAME }}_arm64
           path: ./smarttubetv/build/outputs/apk/stbeta/release/*_arm64-v8a.apk
           if-no-files-found: error
 
       - name: Upload ARMv7 APK
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SmartTube_${{ steps.get_version.outputs.VERSION_NAME }}_armeabi-v7a
           path: ./smarttubetv/build/outputs/apk/stbeta/release/*_armeabi-v7a.apk
           if-no-files-found: error
 
       - name: Upload Universal APK
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SmartTube_${{ steps.get_version.outputs.VERSION_NAME }}_universal
           path: ./smarttubetv/build/outputs/apk/stbeta/release/*_universal.apk
           if-no-files-found: error
 
       - name: Upload x86 APK
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SmartTube_${{ steps.get_version.outputs.VERSION_NAME }}_x86
           path: ./smarttubetv/build/outputs/apk/stbeta/release/*_x86.apk

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       actions: write
     steps:
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const KEEP = 0;

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
       actions: write
       issues: write
     steps:
-    - uses: actions/stale@v10
+    - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         operations-per-run: 3000 # This may result in rate limiting, could we reduce and run in batches?

--- a/.github/workflows/virustotal_scan.yml
+++ b/.github/workflows/virustotal_scan.yml
@@ -31,7 +31,7 @@ jobs:
           echo -e "MARKER=\t\t\t" >> $GITHUB_ENV
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Download Release Assets
         env:
@@ -43,7 +43,7 @@ jobs:
       - name: VirusTotal Scan
         if: ${{ env.HAS_VT_KEY == 'true' }}
         id: vt
-        uses: crazy-max/ghaction-virustotal@v5
+        uses: crazy-max/ghaction-virustotal@936d8c5c00afe97d3d9a1af26d017cfdf26800a2 # v5.0.0
         with:
           vt_api_key: ${{ secrets.VIRUS_TOTAL_API_KEY }}
           files: |


### PR DESCRIPTION
# ci: locks versions of actions using hashes

I have pinned the versions of the actions used in the workflows with hashes.

Pinning GitHub Actions to a commit hash is an effective safeguard against supply chain attacks. By referencing a specific and immutable version of an action, you prevent compromised versions from being automatically integrated into your pipelines.

All the hashed versions match the current versions that were specified, except for `actions/github-script`, which is being updated from `v8` to `v9.0.0`. I’ve checked for breaking changes, and the script isn’t affected by any, so there’s no issue with upgrading to this new version.

Here is the link to the tags for the actions I've pinned, if you want to check the hashes:
- https://github.com/actions/checkout/releases/tag/v6.0.3
- https://github.com/actions/setup-java/releases/tag/v5.2.0
- https://github.com/actions/upload-artifact/releases/tag/v7.0.1
- https://github.com/crazy-max/ghaction-virustotal/releases/tag/v5.0.0
- https://github.com/actions/github-script/releases/tag/v9.0.0
- https://github.com/actions/stale/releases/tag/v10.3.0

Pinning versions requires a bit of maintenance, since you have to perform manual upgrades regularly, but in your case, with workflows that handle secrets (such as `secrets.GITHUB_TOKEN`), it’s a best practice.