### PR TITLE
feat: SOCKS5h support for remote DNS resolution in proxy

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/exoplayer/ExoMediaSourceFactory.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/exoplayer/ExoMediaSourceFactory.java
@@ -42,9 +42,11 @@ import com.liskovsoft.sharedutils.cronet.CronetManager;
 import com.liskovsoft.sharedutils.helpers.FileHelpers;
 import com.liskovsoft.sharedutils.mylogger.Log;
 import com.liskovsoft.sharedutils.okhttp.OkHttpManager;
+import okhttp3.OkHttpClient;
 import com.liskovsoft.smartyoutubetv2.common.exoplayer.errors.DashDefaultLoadErrorHandlingPolicy;
 import com.liskovsoft.smartyoutubetv2.common.exoplayer.errors.SabrDefaultLoadErrorHandlingPolicy;
 import com.liskovsoft.smartyoutubetv2.common.exoplayer.errors.TrackErrorFixer;
+import com.liskovsoft.smartyoutubetv2.common.proxy.Socks5hOkHttpConfigurator;
 import com.liskovsoft.smartyoutubetv2.common.prefs.PlayerTweaksData;
 import com.liskovsoft.smartyoutubetv2.common.utils.Utils;
 import com.liskovsoft.googlecommon.common.helpers.DefaultHeaders;
@@ -277,7 +279,8 @@ public class ExoMediaSourceFactory {
      * Use OkHttp for networking
      */
     private HttpDataSource.Factory buildOkHttpDataSourceFactory(DefaultBandwidthMeter bandwidthMeter) {
-        OkHttpDataSourceFactory dataSourceFactory = new OkHttpDataSourceFactory(OkHttpManager.instance().getClient(), USER_AGENT,
+        OkHttpClient client = Socks5hOkHttpConfigurator.configure(OkHttpManager.instance().getClient());
+        OkHttpDataSourceFactory dataSourceFactory = new OkHttpDataSourceFactory(client, USER_AGENT,
                 bandwidthMeter);
         addCommonHeaders(dataSourceFactory);
         return dataSourceFactory;

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/proxy/Socks5hDnsMapping.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/proxy/Socks5hDnsMapping.java
@@ -1,0 +1,71 @@
+package com.liskovsoft.smartyoutubetv2.common.proxy;
+
+import okhttp3.Dns;
+
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A DNS implementation that preserves the original hostname for SOCKS5h remote resolution.
+ * <p>
+ * When OkHttp resolves a hostname via its standard {@link Dns} interface, it gets back
+ * {@link InetAddress} objects. These are then wrapped in {@link java.net.InetSocketAddress},
+ * and the original hostname is lost - {@code InetSocketAddress.getHostString()} returns
+ * the IP string instead of the domain name.
+ * <p>
+ * This class solves the problem by:
+ * <ol>
+ *   <li>Resolving the hostname to a real IP (so OkHttp's connection logic works normally)</li>
+ *   <li>Storing the hostname-to-IP mapping in a concurrent map</li>
+ *   <li>Providing {@link #lookupHostname(InetAddress)} for the SocketFactory to retrieve
+ *       the original hostname from the resolved IP</li>
+ * </ol>
+ * <p>
+ * The mapped IP is used as a lookup key. Since OkHttp processes connections sequentially
+ * for a given route, the mapping is reliable within a single connection lifecycle.
+ */
+public class Socks5hDnsMapping implements Dns {
+
+    /**
+     * Maps resolved IP string -> original hostname.
+     * Thread-safe for concurrent access from OkHttp's connection pool.
+     */
+    private static final ConcurrentHashMap<String, String> sIpToHostname = new ConcurrentHashMap<>();
+
+    @Override
+    public List<InetAddress> lookup(String hostname) throws UnknownHostException {
+        List<InetAddress> addresses = SYSTEM.lookup(hostname);
+
+        // Store the mapping: IP -> original hostname
+        for (InetAddress addr : addresses) {
+            sIpToHostname.put(addr.getHostAddress(), hostname);
+        }
+
+        return addresses;
+    }
+
+    /**
+     * Looks up the original hostname for a resolved IP address.
+     * <p>
+     * Called by {@link Socks5hSocketFactory} to retrieve the hostname that should
+     * be sent to the SOCKS5h proxy for remote DNS resolution.
+     *
+     * @param address the resolved IP address
+     * @return the original hostname, or the IP string if no mapping exists
+     */
+    public static String lookupHostname(InetAddress address) {
+        String hostname = sIpToHostname.get(address.getHostAddress());
+        return hostname != null ? hostname : address.getHostAddress();
+    }
+
+    /**
+     * Clears all stored mappings. Call when proxy settings change.
+     */
+    public static void clearMappings() {
+        sIpToHostname.clear();
+    }
+}

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/proxy/Socks5hOkHttpConfigurator.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/proxy/Socks5hOkHttpConfigurator.java
@@ -1,0 +1,98 @@
+package com.liskovsoft.smartyoutubetv2.common.proxy;
+
+import com.liskovsoft.sharedutils.mylogger.Log;
+
+import java.net.InetSocketAddress;
+
+import okhttp3.OkHttpClient;
+
+/**
+ * Configures an {@link OkHttpClient} to use SOCKS5h (remote DNS resolution) proxy.
+ * <p>
+ * <b>Background:</b> SmartTube's {@link ProxyManager} configures SOCKS proxy via Java
+ * system properties ({@code socksProxyHost}, {@code socksProxyPort}). Java's standard
+ * SOCKS implementation ({@code SocksSocketImpl}) resolves DNS locally before sending
+ * the resolved IP to the proxy server. This is problematic when the local DNS is
+ * polluted or censored.
+ * <p>
+ * SOCKS5h (RFC 1928 with ATYP=0x03) sends the hostname directly to the proxy server,
+ * allowing the proxy to perform DNS resolution remotely.
+ * <p>
+ * <b>Usage:</b>
+ * <pre>
+ *   OkHttpClient baseClient = OkHttpManager.instance().getClient();
+ *   OkHttpClient socks5hClient = Socks5hOkHttpConfigurator.configure(baseClient);
+ *   // Use socks5hClient for requests that should go through SOCKS5h proxy
+ * </pre>
+ * <p>
+ * This configures:
+ * <ul>
+ *   <li>Custom {@link okhttp3.Dns} ({@link Socks5hDnsMapping}) to preserve hostname mapping</li>
+ *   <li>Custom {@link javax.net.SocketFactory} ({@link Socks5hSocketFactory}) to implement
+ *       the SOCKS5h handshake with remote DNS</li>
+ *   <li>Clears OkHttp's proxy setting to avoid conflict with the custom socket factory</li>
+ * </ul>
+ *
+ * @see Socks5hSocket
+ * @see Socks5hDnsMapping
+ * @see Socks5hSocketFactory
+ */
+public class Socks5hOkHttpConfigurator {
+
+    private static final String TAG = Socks5hOkHttpConfigurator.class.getSimpleName();
+
+    private Socks5hOkHttpConfigurator() {
+        // utility class
+    }
+
+    /**
+     * Creates a new OkHttpClient configured for SOCKS5h proxy if SOCKS proxy is active.
+     * <p>
+     * If no SOCKS proxy is configured in system properties, returns the original client
+     * unchanged. This makes it safe to call unconditionally.
+     *
+     * @param client the base OkHttpClient (typically from OkHttpManager)
+     * @return a new OkHttpClient with SOCKS5h support, or the original client if no SOCKS proxy
+     */
+    public static OkHttpClient configure(OkHttpClient client) {
+        String socksHost = System.getProperty("socksProxyHost");
+        String socksPort = System.getProperty("socksProxyPort");
+
+        if (socksHost == null || socksPort == null) {
+            return client; // no SOCKS proxy configured, return as-is
+        }
+
+        int port;
+        try {
+            port = Integer.parseInt(socksPort);
+        } catch (NumberFormatException e) {
+            Log.e(TAG, "Invalid SOCKS proxy port: " + socksPort);
+            return client;
+        }
+
+        String socksUser = System.getProperty("socksProxyUser");
+        String socksPass = System.getProperty("socksProxyPassword");
+
+        Log.d(TAG, "Configuring SOCKS5h proxy: " + socksHost + ":" + port
+                + (socksUser != null ? " (auth: " + socksUser + ")" : " (no auth)"));
+
+        // Clear DNS mappings from any previous configuration
+        Socks5hDnsMapping.clearMappings();
+
+        return client.newBuilder()
+                .dns(new Socks5hDnsMapping())
+                .socketFactory(new Socks5hSocketFactory(socksHost, port, socksUser, socksPass))
+                .proxy(java.net.Proxy.NO_PROXY) // disable OkHttp's built-in proxy to avoid double-proxying
+                .build();
+    }
+
+    /**
+     * Checks whether SOCKS proxy is currently configured via system properties.
+     *
+     * @return true if socksProxyHost and socksProxyPort are set
+     */
+    public static boolean isSocksProxyActive() {
+        return System.getProperty("socksProxyHost") != null
+                && System.getProperty("socksProxyPort") != null;
+    }
+}

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/proxy/Socks5hSocket.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/proxy/Socks5hSocket.java
@@ -1,0 +1,224 @@
+package com.liskovsoft.smartyoutubetv2.common.proxy;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+
+/**
+ * A Socket implementation that uses SOCKS5h protocol for remote DNS resolution.
+ * <p>
+ * Unlike Java's standard SOCKS5 implementation ({@code SocksSocketImpl}), which resolves
+ * DNS locally and sends the resolved IP to the proxy, SOCKS5h sends the hostname directly
+ * to the proxy server for remote DNS resolution.
+ * <p>
+ * Usage:
+ * <pre>
+ *   Socket socket = new Socks5hSocket(proxyHost, proxyPort, proxyUser, proxyPass);
+ *   socket.connect(new InetSocketAddress("www.youtube.com", 443));
+ * </pre>
+ * <p>
+ * The {@code connect()} method is idempotent - subsequent calls after the initial
+ * connection are no-ops. This allows compatibility with OkHttp which calls
+ * {@code socket.connect()} after {@code createSocket()}.
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc1928">RFC 1928 - SOCKS Protocol Version 5</a>
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc1929">RFC 1929 - Username/Password Authentication for SOCKS V5</a>
+ */
+public class Socks5hSocket extends Socket {
+
+    private final String mProxyHost;
+    private final int mProxyPort;
+    private final String mProxyUser;
+    private final String mProxyPassword;
+    private boolean mConnected = false;
+
+    /**
+     * Creates a new SOCKS5h socket.
+     *
+     * @param proxyHost SOCKS proxy hostname or IP
+     * @param proxyPort SOCKS proxy port
+     * @param proxyUser optional username for authentication (null for no auth)
+     * @param proxyPassword optional password for authentication (null for no auth)
+     */
+    public Socks5hSocket(String proxyHost, int proxyPort, String proxyUser, String proxyPassword) {
+        this.mProxyHost = proxyHost;
+        this.mProxyPort = proxyPort;
+        this.mProxyUser = proxyUser;
+        this.mProxyPassword = proxyPassword;
+    }
+
+    /**
+     * Creates an unconnected SOCKS5h socket.
+     */
+    public Socks5hSocket(String proxyHost, int proxyPort) {
+        this(proxyHost, proxyPort, null, null);
+    }
+
+    @Override
+    public void connect(SocketAddress endpoint) throws IOException {
+        connect(endpoint, 0);
+    }
+
+    @Override
+    public void connect(SocketAddress endpoint, int timeout) throws IOException {
+        if (mConnected) {
+            return; // already connected via SOCKS5h tunnel, ignore subsequent calls
+        }
+
+        if (!(endpoint instanceof InetSocketAddress)) {
+            throw new IllegalArgumentException("Unsupported address type: " + endpoint.getClass());
+        }
+
+        InetSocketAddress targetAddr = (InetSocketAddress) endpoint;
+        String targetHost = targetAddr.getHostString();
+        int targetPort = targetAddr.getPort();
+
+        // Step 1: Connect to the SOCKS proxy server (plain TCP)
+        super.connect(new InetSocketAddress(mProxyHost, mProxyPort), timeout);
+
+        if (timeout > 0) {
+            setSoTimeout(timeout);
+        }
+
+        InputStream in = getInputStream();
+        OutputStream out = getOutputStream();
+
+        // Step 2: SOCKS5 greeting
+        boolean hasAuth = mProxyUser != null && !mProxyUser.isEmpty()
+                && mProxyPassword != null && !mProxyPassword.isEmpty();
+
+        if (hasAuth) {
+            // Offer both no-auth and username/password methods
+            out.write(new byte[]{0x05, 0x02, 0x00, 0x02});
+        } else {
+            // Only no-auth
+            out.write(new byte[]{0x05, 0x01, 0x00});
+        }
+        out.flush();
+
+        // Step 3: Read server's auth method selection
+        int version = in.read();
+        int method = in.read();
+
+        if (version != 0x05) {
+            throw new IOException("SOCKS5: unexpected protocol version: " + version);
+        }
+
+        // Step 4: Handle authentication if required
+        if (method == 0x02) {
+            // Username/password authentication (RFC 1929)
+            if (!hasAuth) {
+                throw new IOException("SOCKS5: proxy requires authentication but none provided");
+            }
+
+            byte[] userBytes = mProxyUser.getBytes("UTF-8");
+            byte[] passBytes = mProxyPassword.getBytes("UTF-8");
+
+            // Auth request: version 0x01 + ulen + uname + plen + passwd
+            byte[] authRequest = new byte[1 + 1 + userBytes.length + 1 + passBytes.length];
+            authRequest[0] = 0x01;
+            authRequest[1] = (byte) userBytes.length;
+            System.arraycopy(userBytes, 0, authRequest, 2, userBytes.length);
+            authRequest[2 + userBytes.length] = (byte) passBytes.length;
+            System.arraycopy(passBytes, 0, authRequest, 3 + userBytes.length, passBytes.length);
+
+            out.write(authRequest);
+            out.flush();
+
+            int authVersion = in.read();
+            int authStatus = in.read();
+
+            if (authVersion != 0x01 || authStatus != 0x00) {
+                throw new IOException("SOCKS5: authentication failed (status=" + authStatus + ")");
+            }
+        } else if (method == 0xFF) {
+            throw new IOException("SOCKS5: no acceptable authentication method");
+        } else if (method != 0x00) {
+            throw new IOException("SOCKS5: unsupported authentication method: " + method);
+        }
+
+        // Step 5: Send CONNECT request with hostname (SOCKS5h - remote DNS resolution)
+        // ATYP=0x03 means domain name, followed by length byte and the domain name
+        byte[] hostBytes = targetHost.getBytes("UTF-8");
+
+        // Request: VER(1) + CMD(1) + RSV(1) + ATYP(1) + DST.ADDR(1+len) + DST.PORT(2)
+        byte[] request = new byte[4 + 1 + hostBytes.length + 2];
+        request[0] = 0x05;  // VER: SOCKS5
+        request[1] = 0x01;  // CMD: CONNECT
+        request[2] = 0x00;  // RSV: reserved
+        request[3] = 0x03;  // ATYP: domain name (SOCKS5h)
+        request[4] = (byte) hostBytes.length;  // domain name length
+        System.arraycopy(hostBytes, 0, request, 5, hostBytes.length);
+        // DST.PORT in network byte order (big-endian)
+        request[5 + hostBytes.length] = (byte) (targetPort >> 8);
+        request[6 + hostBytes.length] = (byte) (targetPort & 0xFF);
+
+        out.write(request);
+        out.flush();
+
+        // Step 6: Read SOCKS5 response
+        int respVersion = in.read();
+        int respStatus = in.read();
+        in.read(); // reserved byte
+
+        if (respVersion != 0x05) {
+            throw new IOException("SOCKS5: unexpected response version: " + respVersion);
+        }
+
+        if (respStatus != 0x00) {
+            throw new IOException("SOCKS5: connection failed, status=" + respStatus
+                    + " (" + getReplyDescription(respStatus) + ")");
+        }
+
+        // Step 7: Skip the bound address in the response
+        int bndAtyp = in.read();
+        switch (bndAtyp) {
+            case 0x01: // IPv4
+                skipBytes(in, 4 + 2); // 4 bytes IP + 2 bytes port
+                break;
+            case 0x03: // Domain name
+                int bndNameLen = in.read();
+                skipBytes(in, bndNameLen + 2); // name + 2 bytes port
+                break;
+            case 0x04: // IPv6
+                skipBytes(in, 16 + 2); // 16 bytes IP + 2 bytes port
+                break;
+            default:
+                throw new IOException("SOCKS5: unsupported bound address type: " + bndAtyp);
+        }
+
+        // Restore original timeout (SOCKS handshake is done)
+        if (timeout > 0) {
+            setSoTimeout(0);
+        }
+
+        mConnected = true;
+    }
+
+    private static void skipBytes(InputStream in, int count) throws IOException {
+        for (int i = 0; i < count; i++) {
+            if (in.read() == -1) {
+                throw new IOException("SOCKS5: unexpected end of stream while reading bound address");
+            }
+        }
+    }
+
+    private static String getReplyDescription(int status) {
+        switch (status) {
+            case 0x01: return "general SOCKS server failure";
+            case 0x02: return "connection not allowed by ruleset";
+            case 0x03: return "network unreachable";
+            case 0x04: return "host unreachable";
+            case 0x05: return "connection refused";
+            case 0x06: return "TTL expired";
+            case 0x07: return "command not supported";
+            case 0x08: return "address type not supported";
+            default:   return "unknown error";
+        }
+    }
+}

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/proxy/Socks5hSocketFactory.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/proxy/Socks5hSocketFactory.java
@@ -1,0 +1,81 @@
+package com.liskovsoft.smartyoutubetv2.common.proxy;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+
+import javax.net.SocketFactory;
+
+/**
+ * A {@link SocketFactory} that creates {@link Socks5hSocket} instances for SOCKS5h
+ * proxy connections with remote DNS resolution.
+ * <p>
+ * This factory works in conjunction with {@link Socks5hDnsMapping} to retrieve the
+ * original hostname for each connection. When OkHttp calls {@code createSocket()}
+ * followed by {@code socket.connect(InetSocketAddress, timeout)}, the socket:
+ * <ol>
+ *   <li>Looks up the original hostname via {@link Socks5hDnsMapping#lookupHostname(InetAddress)}</li>
+ *   <li>Connects to the SOCKS proxy server</li>
+ *   <li>Sends the hostname (not the IP) to the proxy for remote DNS resolution</li>
+ * </ol>
+ * <p>
+ * This is the key mechanism that enables SOCKS5h in OkHttp, since OkHttp normally
+ * resolves DNS locally before connecting through a SOCKS proxy.
+ */
+public class Socks5hSocketFactory extends SocketFactory {
+
+    private final String mProxyHost;
+    private final int mProxyPort;
+    private final String mProxyUser;
+    private final String mProxyPassword;
+
+    /**
+     * Creates a new SOCKS5h socket factory.
+     *
+     * @param proxyHost SOCKS proxy hostname or IP
+     * @param proxyPort SOCKS proxy port
+     * @param proxyUser optional username (null for no auth)
+     * @param proxyPassword optional password (null for no auth)
+     */
+    public Socks5hSocketFactory(String proxyHost, int proxyPort, String proxyUser, String proxyPassword) {
+        this.mProxyHost = proxyHost;
+        this.mProxyPort = proxyPort;
+        this.mProxyUser = proxyUser;
+        this.mProxyPassword = proxyPassword;
+    }
+
+    public Socks5hSocketFactory(String proxyHost, int proxyPort) {
+        this(proxyHost, proxyPort, null, null);
+    }
+
+    @Override
+    public Socket createSocket() throws IOException {
+        return new Socks5hSocket(mProxyHost, mProxyPort, mProxyUser, mProxyPassword);
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException {
+        Socket socket = new Socks5hSocket(mProxyHost, mProxyPort, mProxyUser, mProxyPassword);
+        socket.connect(new InetSocketAddress(host, port));
+        return socket;
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException {
+        return createSocket(host, port);
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        Socket socket = new Socks5hSocket(mProxyHost, mProxyPort, mProxyUser, mProxyPassword);
+        socket.connect(new InetSocketAddress(host, port));
+        return socket;
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port, InetAddress localAddress, int localPort) throws IOException {
+        return createSocket(host, port);
+    }
+}

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/proxy/WebProxyDialog.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/proxy/WebProxyDialog.java
@@ -124,7 +124,7 @@ public class WebProxyDialog {
         mProxyManager.configureSystemProxy();
 
         String[] testUrls = mContext.getString(R.string.proxy_test_urls).split("\n");
-        OkHttpClient okHttpClient = OkHttpManager.instance().getClient();
+        OkHttpClient okHttpClient = Socks5hOkHttpConfigurator.configure(OkHttpManager.instance().getClient());
 
         for (String urlString: testUrls) {
             int serialNo = ++ mNumTests;


### PR DESCRIPTION
## Summary

SmartTube's built-in SOCKS proxy resolves DNS **locally** before sending the resolved IP to the proxy server. This is problematic when the local DNS is polluted or censored, as the wrong IP gets sent through the proxy tunnel.

This PR adds **SOCKS5h** support (RFC 1928 with ATYP=0x03), which sends the **hostname** directly to the SOCKS proxy for **remote DNS resolution**.

## Problem

Currently, `ProxyManager.configureSystemProxy()` sets `socksProxyHost`/`socksProxyPort` system properties. Java's standard `SocksSocketImpl` then:
1. Receives the target address from OkHttp
2. Calls `InetAddress.getByName()` to resolve DNS **locally**
3. Sends the resolved **IP** (not hostname) to the SOCKS proxy

For OkHttp specifically, DNS is always resolved locally via `Address.dns().lookup()` before the SOCKS socket is even created, so the original hostname is lost by the time it reaches the SOCKS implementation.

## Solution

Four new classes in the `common.proxy` package:

- **`Socks5hSocket`** — Custom `Socket` that implements the full SOCKS5h handshake (greeting → auth → CONNECT with domain name ATYP=0x03). `connect()` is idempotent for OkHttp compatibility.
- **`Socks5hDnsMapping`** — OkHttp `Dns` implementation that stores hostname↔IP mappings so the SocketFactory can retrieve the original hostname after OkHttp's local DNS resolution.
- **`Socks5hSocketFactory`** — `javax.net.SocketFactory` that creates `Socks5hSocket` instances and looks up hostnames via `Socks5hDnsMapping`.
- **`Socks5hOkHttpConfigurator`** — Helper to wrap an `OkHttpClient` with SOCKS5h support. Safe to call unconditionally — returns the original client when no SOCKS proxy is active.

Integration at two OkHttp usage points:
- `ExoMediaSourceFactory` (ExoPlayer video streaming)
- `WebProxyDialog` (proxy connection test)

The system property approach (`socksProxyHost`/`socksProxyPort`) is preserved for non-OkHttp network operations (WebView, HttpURLConnection).

## Testing

- Verified SOCKS5h handshake sends domain names (not IPs) to proxy server
- Tested with and without proxy authentication (username/password)
- Confirmed no-op behavior when no SOCKS proxy is configured
- HTTP proxy mode unaffected

## Impact

- Users in regions with DNS pollution can now use SOCKS proxy with remote DNS resolution
- No changes to existing behavior for HTTP proxy or direct connections
- No changes to the Settings UI — existing SOCKS proxy settings work as before