### PR TITLE
player: remember video preset per channel

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/HQDialogController.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/HQDialogController.java
@@ -190,6 +190,13 @@ public class HQDialogController extends BasePlayerController {
     //}
 
     private void addPresetsCategory() {
+        // Per channel presets (same as the speed list)
+        if (getPlayerData().isFormatPerChannelEnabled() && getPlayer() != null
+                && getPlayer().getVideo() != null && getPlayer().getVideo().channelId != null) {
+            addPresetsPerChannelCategory();
+            return;
+        }
+
         addCategoryInt(AppDialogUtil.createVideoPresetsCategory(
                 getContext(), () -> {
                     if (getPlayer() == null) {
@@ -197,6 +204,31 @@ public class HQDialogController extends BasePlayerController {
                     }
 
                     FormatItem format = getPlayerData().getFormat(FormatItem.TYPE_VIDEO);
+                    getPlayer().setFormat(format);
+
+                    if (!getPlayer().containsMedia()) {
+                        getPlayer().reloadPlayback();
+                    }
+
+                    // Make result easily be spotted by the user
+                    getPlayer().showOverlay(false);
+                }
+        ));
+    }
+
+    private void addPresetsPerChannelCategory() {
+        addCategoryInt(AppDialogUtil.createVideoPresetsPerChannelCategory(
+                getContext(), getPlayer().getVideo().channelId, () -> {
+                    if (getPlayer() == null || getPlayer().getVideo() == null) {
+                        return;
+                    }
+
+                    FormatItem format = getPlayerData().getFormatPerChannel(getPlayer().getVideo().channelId);
+
+                    if (format == null) {
+                        format = getPlayerData().getFormat(FormatItem.TYPE_VIDEO);
+                    }
+
                     getPlayer().setFormat(format);
 
                     if (!getPlayer().containsMedia()) {

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/VideoStateController.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/VideoStateController.java
@@ -148,6 +148,10 @@ public class VideoStateController extends BasePlayerController {
         // Channel info should be loaded at this point
         if (getVideo() != null && !getVideo().isRemote) {
             restoreSubtitleFormat();
+            // Channel id is set only now, so reapply the per channel format
+            if (getPlayerData().isFormatPerChannelEnabled() && getPlayerData().getFormatPerChannel(getVideo().channelId) != null) {
+                restoreVideoFormat();
+            }
         }
 
         // Need to contain channel id
@@ -403,8 +407,14 @@ public class VideoStateController extends BasePlayerController {
             return;
         }
 
+        Video video = getPlayer().getVideo();
+        FormatItem formatPerChannel = getPlayerData().isFormatPerChannelEnabled() && video != null
+                ? getPlayerData().getFormatPerChannel(video.channelId) : null;
+
         if (getPlayerData().getTempVideoFormat() != null) {
             getPlayer().setFormat(getPlayerData().getTempVideoFormat());
+        } else if (formatPerChannel != null) {
+            getPlayer().setFormat(formatPerChannel);
         } else {
             getPlayer().setFormat(getPlayerData().getFormat(FormatItem.TYPE_VIDEO));
         }

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/settings/PlayerSettingsPresenter.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/settings/PlayerSettingsPresenter.java
@@ -486,6 +486,8 @@ public class PlayerSettingsPresenter extends BasePresenter<Void> {
                 option -> mPlayerTweaksData.setQueueRespectsPlaybackMode(option.isSelected()),
                 mPlayerTweaksData.isQueueRespectsPlaybackMode()));
 
+        options.add(AppDialogUtil.createVideoPresetChannelOption(getContext()));
+
         settingsPresenter.appendCheckedCategory(getContext().getString(R.string.player_other), options);
     }
 

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/prefs/PlayerData.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/prefs/PlayerData.java
@@ -95,6 +95,8 @@ public class PlayerData extends DataChangeBase implements PlayerConstants, Profi
     private boolean mIsSubtitlesPerChannelEnabled;
     private boolean mIsSpeedPerChannelEnabled;
     private final Map<String, SpeedItem> mSpeeds = new HashMap<>();
+    private final Map<String, ChannelFormat> mFormatsPerChannel = new HashMap<>();
+    private boolean mIsFormatPerChannelEnabled;
     private float mPitch;
     private long mAfrSwitchTimeMs;
     private List<String> mLastAudioLanguages;
@@ -125,6 +127,32 @@ public class PlayerData extends DataChangeBase implements PlayerConstants, Profi
         @Override
         public String toString() {
             return Helpers.mergeObj(channelId, speed);
+        }
+    }
+
+    private static class ChannelFormat {
+        public String channelId;
+        public FormatItem format;
+
+        public ChannelFormat(String channelId, FormatItem format) {
+            this.channelId = channelId;
+            this.format = format;
+        }
+
+        public static ChannelFormat fromString(String specs) {
+            String[] split = Helpers.splitObj(specs);
+
+            if (split == null || split.length != 2) {
+                return new ChannelFormat(null, null);
+            }
+
+            return new ChannelFormat(Helpers.parseStr(split[0]), ExoFormatItem.from(Helpers.parseStr(split[1])));
+        }
+
+        @NonNull
+        @Override
+        public String toString() {
+            return Helpers.mergeObj(channelId, format);
         }
     }
 
@@ -406,6 +434,39 @@ public class PlayerData extends DataChangeBase implements PlayerConstants, Profi
 
     public FormatItem getTempVideoFormat() {
         return mTempVideoFormat;
+    }
+
+    public FormatItem getFormatPerChannel(String channelId) {
+        if (channelId == null) {
+            return null;
+        }
+
+        ChannelFormat format = mFormatsPerChannel.get(channelId);
+
+        return format != null ? format.format : null;
+    }
+
+    public void setFormatPerChannel(String channelId, FormatItem format) {
+        if (channelId == null) {
+            return;
+        }
+
+        if (format == null) {
+            mFormatsPerChannel.remove(channelId);
+        } else {
+            mFormatsPerChannel.put(channelId, new ChannelFormat(channelId, format));
+        }
+
+        persistState();
+    }
+
+    public boolean isFormatPerChannelEnabled() {
+        return mIsFormatPerChannelEnabled;
+    }
+
+    public void setFormatPerChannelEnabled(boolean enable) {
+        mIsFormatPerChannelEnabled = enable;
+        persistState();
     }
 
     public FormatItem getLastSubtitleFormat() {
@@ -847,11 +908,20 @@ public class PlayerData extends DataChangeBase implements PlayerConstants, Profi
         mLastAudioLanguages = Helpers.parseStrList(split, 60);
         mIsVideoFlipEnabled = Helpers.parseBoolean(split, 61, false);
         mIsAudioDelayEnabled = Helpers.parseBoolean(split, 62, false);
+        String[] formatsPerChannel = Helpers.parseArray(split, 63);
+        mIsFormatPerChannelEnabled = Helpers.parseBoolean(split, 64, false);
 
         if (speeds != null) {
             for (String speedSpec : speeds) {
                 SpeedItem item = SpeedItem.fromString(speedSpec);
                 mSpeeds.put(item.channelId, item);
+            }
+        }
+
+        if (formatsPerChannel != null) {
+            for (String formatSpec : formatsPerChannel) {
+                ChannelFormat item = ChannelFormat.fromString(formatSpec);
+                mFormatsPerChannel.put(item.channelId, item);
             }
         }
 
@@ -884,7 +954,8 @@ public class PlayerData extends DataChangeBase implements PlayerConstants, Profi
                 mIsNumberKeySeekEnabled, mIsSkip24RateEnabled, mAfrPauseMs, mIsLiveChatEnabled, mLastSubtitleFormats, mLastSpeed, mRotationAngle,
                 mZoomPercents, mPlaybackMode, mAudioLanguage, mSubtitleLanguage, mEnabledSubtitlesPerChannel, mIsSubtitlesPerChannelEnabled,
                 mIsSpeedPerChannelEnabled, Helpers.mergeArray(mSpeeds.values().toArray()), mPitch, mIsSkipShortsEnabled, mLastAudioLanguages,
-                mIsVideoFlipEnabled, mIsAudioDelayEnabled
+                mIsVideoFlipEnabled, mIsAudioDelayEnabled, Helpers.mergeArray(mFormatsPerChannel.values().toArray()),
+                mIsFormatPerChannelEnabled
         ));
     }
 
@@ -894,6 +965,7 @@ public class PlayerData extends DataChangeBase implements PlayerConstants, Profi
 
         // reset on profile change
         mSpeeds.clear();
+        mFormatsPerChannel.clear();
 
         restoreState();
     }

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/utils/AppDialogUtil.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/utils/AppDialogUtil.java
@@ -80,6 +80,7 @@ public class AppDialogUtil {
     private static final int PLAYER_ENGINE_ID = 147;
     private static final int IGNORE_DURATION_ID = 148;
     private static final int SLEEP_TIMER_ID = 149;
+    private static final int VIDEO_PRESETS_PER_CHANNEL_ID = 150;
     private static final int SUBTITLE_STYLES_ID = 45;
     private static final int SUBTITLE_SIZE_ID = 46;
     private static final int SUBTITLE_POSITION_ID = 47;
@@ -305,6 +306,60 @@ public class AppDialogUtil {
                 context.getString(R.string.option_disabled),
                 optionItem -> setFormat(playerData.getDefaultVideoFormat(), playerData, onFormatSelected),
                 !isPresetSelection));
+
+        return result;
+    }
+
+    public static OptionItem createVideoPresetChannelOption(Context context) {
+        PlayerData playerData = PlayerData.instance(context);
+        return UiOptionItem.from(context.getString(R.string.video_preset_per_channel),
+                optionItem -> playerData.setFormatPerChannelEnabled(optionItem.isSelected()),
+                playerData.isFormatPerChannelEnabled()
+        );
+    }
+
+    public static OptionCategory createVideoPresetsPerChannelCategory(Context context, String channelId, Runnable onFormatSelected) {
+        return OptionCategory.from(
+                VIDEO_PRESETS_PER_CHANNEL_ID,
+                OptionCategory.TYPE_RADIO_LIST,
+                context.getString(R.string.title_video_presets),
+                fromChannelPresets(
+                        context,
+                        AppDataSourceManager.instance().getVideoPresets(),
+                        channelId,
+                        onFormatSelected
+                )
+        );
+    }
+
+    private static List<OptionItem> fromChannelPresets(Context context, VideoPreset[] presets, String channelId, Runnable onFormatSelected) {
+        List<OptionItem> result = new ArrayList<>();
+
+        PlayerData playerData = PlayerData.instance(context);
+        PlayerTweaksData playerTweaksData = PlayerTweaksData.instance(context);
+        FormatItem selectedFormat = playerData.getFormatPerChannel(channelId);
+        boolean isAllFormatsUnlocked = playerTweaksData.isAllFormatsUnlocked();
+
+        for (VideoPreset preset : presets) {
+            if (!isAllFormatsUnlocked && !Utils.isPresetSupported(preset)) {
+                continue;
+            }
+
+            result.add(0, UiOptionItem.from(preset.name,
+                    option -> {
+                        playerData.setFormatPerChannel(channelId, preset.format);
+                        onFormatSelected.run();
+                    },
+                    preset.format.equals(selectedFormat)));
+        }
+
+        result.add(0, UiOptionItem.from(
+                context.getString(R.string.option_disabled),
+                optionItem -> {
+                    playerData.setFormatPerChannel(channelId, null);
+                    onFormatSelected.run();
+                },
+                selectedFormat == null));
 
         return result;
     }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -48,6 +48,7 @@
     <string name="msg_signed_users_only">Signed users only</string>
     <string name="msg_cant_load_content">Can\'t load content.\n1) Turn on watch history.\n2) Check date and time on the device.\n3) Check network connection.\n4) Check your proxy settings.\n5) Try to sign in to your account.\n6) Maybe there is nothing in here.</string>
     <string name="title_video_presets">Video presets</string>
+    <string name="video_preset_per_channel">Remember video preset per channel</string>
     <string name="settings_accounts">Accounts</string>
     <string name="settings_left_panel">Edit categories</string>
     <string name="settings_themes">Themes</string>


### PR DESCRIPTION
Adds an option to remember the video preset per channel.

Works like the existing per-channel speed/subtitles: when enabled, the preset you pick in "Video presets" is stored for the current channel and reapplied on its videos; other channels keep the global preset. Off by default. The toggle is currently under Player settings > Misc.

**Question**: where would you prefer this toggle to live? I put it in Misc for now, but it could sit next to "Video presets" (like the per-channel speed option sits with the speed list). Happy to move it.