### PR TITLE
Player: recover in place from transient MediaCodec errors

### DIFF
--- a/exoplayer-amzn-2.10.6/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
+++ b/exoplayer-amzn-2.10.6/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
@@ -28,6 +28,7 @@ import android.os.SystemClock;
 import androidx.annotation.CheckResult;
 import androidx.annotation.IntDef;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import com.google.android.exoplayer2.BaseRenderer;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.ExoPlaybackException;
@@ -342,6 +343,16 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
   @DrainAction private int codecDrainAction;
   private boolean codecReceivedBuffers;
   private boolean codecReceivedEos;
+  // SmartTube fix: transient MediaCodec error recovery.
+  // A transient codec IllegalStateException is recovered in place (codec re-init) instead of
+  // surfacing as an unrecoverable TYPE_UNEXPECTED player error (full engine restart + error toast).
+  // A short per-window attempt budget prevents a permanently wedged codec from re-initializing in a
+  // tight loop; once exhausted we surface the error (with a real message) and let the app restart the
+  // engine, as it did before this fix.
+  private static final int MAX_CODEC_RECOVERY_ATTEMPTS = 3;
+  private static final long CODEC_RECOVERY_WINDOW_MS = 5_000;
+  private int codecRecoveryAttempts;
+  private long lastCodecRecoveryMs = C.TIME_UNSET;
   private long lastBufferInStreamPresentationTimeUs;
   private long largestQueuedPresentationTimeUs;
   private boolean inputStreamEnded;
@@ -667,9 +678,20 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
     if (codec != null) {
       long drainStartTimeMs = SystemClock.elapsedRealtime();
       TraceUtil.beginSection("drainAndFeed");
-      while (drainOutputBuffer(positionUs, elapsedRealtimeUs)) {}
-      while (feedInputBuffer() && shouldContinueFeeding(drainStartTimeMs)) {}
-      TraceUtil.endSection();
+      try {
+        while (drainOutputBuffer(positionUs, elapsedRealtimeUs)) {}
+        while (feedInputBuffer() && shouldContinueFeeding(drainStartTimeMs)) {}
+      } catch (IllegalStateException e) {
+        // SmartTube fix: a native MediaCodec error would otherwise propagate as
+        // TYPE_UNEXPECTED. Try to recover in place; only surface a (typed) error if that fails.
+        if (isMediaCodecException(e)) {
+          maybeRecoverFromCodecError(e);
+        } else {
+          throw e;
+        }
+      } finally {
+        TraceUtil.endSection();
+      }
     } else {
       decoderCounters.skippedInputBufferCount += skipSource(positionUs);
       // We need to read any format changes despite not having a codec so that drmSession can be
@@ -679,6 +701,92 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
       readToFlagsOnlyBuffer(/* requireFormat= */ false);
     }
     decoderCounters.ensureUpdated();
+  }
+
+  /**
+   * SmartTube fix: recover from a transient MediaCodec
+   * {@link IllegalStateException} by re-initializing the codec in place, instead of letting it
+   * surface as an unrecoverable player error (which forces a full engine restart and an "Unexpected
+   * playback error" toast).
+   *
+   * <p>Repeated failures within {@link #CODEC_RECOVERY_WINDOW_MS} (a permanently wedged codec) exhaust
+   * {@link #MAX_CODEC_RECOVERY_ATTEMPTS} and fall through to {@link #createDecoderException}, so the
+   * old restart-based recovery still acts as a backstop.
+   */
+  private void maybeRecoverFromCodecError(IllegalStateException error) throws ExoPlaybackException {
+    long nowMs = SystemClock.elapsedRealtime();
+    if (lastCodecRecoveryMs == C.TIME_UNSET || nowMs - lastCodecRecoveryMs > CODEC_RECOVERY_WINDOW_MS) {
+      codecRecoveryAttempts = 0;
+    }
+    lastCodecRecoveryMs = nowMs;
+
+    if (codecRecoveryAttempts >= MAX_CODEC_RECOVERY_ATTEMPTS) {
+      throw createDecoderException(error);
+    }
+
+    codecRecoveryAttempts++;
+    Log.w(TAG, "Recovering from MediaCodec error, re-initializing decoder (attempt "
+        + codecRecoveryAttempts + "/" + MAX_CODEC_RECOVERY_ATTEMPTS + ")");
+    try {
+      // A wedged codec's stop() can throw inside releaseCodec(), but releaseCodec()'s own finally has
+      // already nulled the codec by then, so a fresh init can still proceed. Don't let that abort the
+      // recovery.
+      try {
+        releaseCodec();
+      } catch (Throwable ignored) {
+        // Codec already released; continue to re-init.
+      }
+      maybeInitCodec();
+    } catch (ExoPlaybackException reinitError) {
+      throw reinitError;
+    } catch (Throwable reinitError) {
+      throw createDecoderException(error);
+    }
+  }
+
+  /**
+   * Wraps a MediaCodec {@link IllegalStateException} (which normally carries a {@code null} message)
+   * with the decoder name and, when available, the codec's diagnostic info, and reports it as an
+   * {@code UNEXPECTED} error.
+   *
+   * <p>We deliberately do NOT use {@link ExoPlaybackException#createForRenderer} here. A
+   * {@code TYPE_RENDERER} video error routes into the app's ErrorFixerController, which reacts by
+   * persisting a fallback format ({@code VIDEO_FHD_AVC_30}) — wiping the user's saved video preset.
+   * Keeping {@code TYPE_UNEXPECTED} preserves the (non-destructive) pre-fix restart path for an
+   * unrecoverable transient error, while still replacing the bare {@code null} message with a real
+   * one so it's no longer reported as "Unexpected playback error null".
+   */
+  private ExoPlaybackException createDecoderException(IllegalStateException error) {
+    String diagnosticInfo = getCodecDiagnosticInfo(error);
+    String message = "MediaCodec decoder error (" + codecName + ")"
+        + (diagnosticInfo != null ? ": " + diagnosticInfo : "");
+    return ExoPlaybackException.createForUnexpected(new IllegalStateException(message, error));
+  }
+
+  private static String getCodecDiagnosticInfo(IllegalStateException error) {
+    if (Util.SDK_INT >= 21) {
+      return getCodecDiagnosticInfoV21(error);
+    }
+    return null;
+  }
+
+  @TargetApi(21)
+  private static String getCodecDiagnosticInfoV21(IllegalStateException error) {
+    return error instanceof CodecException ? ((CodecException) error).getDiagnosticInfo() : null;
+  }
+
+  @VisibleForTesting
+  /* package */ static boolean isMediaCodecException(IllegalStateException error) {
+    if (Util.SDK_INT >= 21 && isMediaCodecExceptionV21(error)) {
+      return true;
+    }
+    StackTraceElement[] stackTrace = error.getStackTrace();
+    return stackTrace.length > 0 && stackTrace[0].getClassName().equals("android.media.MediaCodec");
+  }
+
+  @TargetApi(21)
+  private static boolean isMediaCodecExceptionV21(IllegalStateException error) {
+    return error instanceof CodecException;
   }
 
   /**

--- a/exoplayer-amzn-2.10.6/library/core/src/test/java/com/google/android/exoplayer2/mediacodec/MediaCodecRendererTest.java
+++ b/exoplayer-amzn-2.10.6/library/core/src/test/java/com/google/android/exoplayer2/mediacodec/MediaCodecRendererTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.exoplayer2.mediacodec;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit test for the transient-MediaCodec-error classification used by the in-place codec recovery
+ * (SmartTube fix). {@link MediaCodecRenderer#isMediaCodecException} is the gate that decides
+ * whether a render-loop {@link IllegalStateException} is treated as a recoverable decoder error, so
+ * these tests pin the two real-world crash signatures we observed (a native {@code MediaCodec} frame
+ * at the top of the stack) and guard against unrelated exceptions being swallowed.
+ *
+ * <p>Deliberately a plain JUnit test (no Robolectric): it exercises only stack-trace inspection, and
+ * the 2019-era Robolectric bundled with this ExoPlayer fork cannot run under the JDK 17 required by
+ * the app's Android Gradle Plugin. Under a plain JVM {@code Util.SDK_INT} reads as 0, so this
+ * exercises the stack-frame branch — which is exactly the path that fired on the real crashes (both
+ * were plain {@link IllegalStateException}s, not {@code MediaCodec.CodecException}s).
+ */
+public class MediaCodecRendererTest {
+
+  @Test
+  public void isMediaCodecException_withNativeDequeueInputBufferFrame_returnsTrue() {
+    // Observed crash: MediaCodec.native_dequeueInputBuffer on VP9 1080p60.
+    IllegalStateException error =
+        illegalStateExceptionWithTopFrame(
+            "android.media.MediaCodec", "native_dequeueInputBuffer");
+
+    assertThat(MediaCodecRenderer.isMediaCodecException(error)).isTrue();
+  }
+
+  @Test
+  public void isMediaCodecException_withReleaseOutputBufferFrame_returnsTrue() {
+    // Observed crash: MediaCodec.releaseOutputBuffer on VP9 1920x960.
+    IllegalStateException error =
+        illegalStateExceptionWithTopFrame("android.media.MediaCodec", "releaseOutputBuffer");
+
+    assertThat(MediaCodecRenderer.isMediaCodecException(error)).isTrue();
+  }
+
+  @Test
+  public void isMediaCodecException_withUnrelatedFrame_returnsFalse() {
+    // A logic-bug ISE originating elsewhere must still propagate untouched.
+    IllegalStateException error =
+        illegalStateExceptionWithTopFrame(
+            "com.google.android.exoplayer2.SomeOtherComponent", "doWork");
+
+    assertThat(MediaCodecRenderer.isMediaCodecException(error)).isFalse();
+  }
+
+  @Test
+  public void isMediaCodecException_withEmptyStackTrace_returnsFalse() {
+    IllegalStateException error = new IllegalStateException();
+    error.setStackTrace(new StackTraceElement[0]);
+
+    assertThat(MediaCodecRenderer.isMediaCodecException(error)).isFalse();
+  }
+
+  private static IllegalStateException illegalStateExceptionWithTopFrame(
+      String className, String methodName) {
+    IllegalStateException error = new IllegalStateException();
+    error.setStackTrace(
+        new StackTraceElement[] {
+          new StackTraceElement(className, methodName, /* fileName= */ null, /* lineNumber= */ -2),
+          new StackTraceElement(
+              "com.google.android.exoplayer2.mediacodec.MediaCodecRenderer",
+              "feedInputBuffer",
+              "MediaCodecRenderer.java",
+              994)
+        });
+    return error;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #5684 ("Unexpected playback error null").

Adds in-place MediaCodec error recovery to the vendored `exoplayer-amzn-2.10.6` fork. On some devices a transient, message-less `IllegalStateException` is thrown from the native decoder — e.g. `MediaCodec.native_dequeueInputBuffer` / `releaseOutputBuffer`, observed on hardware VP9 (MediaTek `c2.mtk.vp9.decoder`) deep into long videos. Today that propagates as an `ExoPlaybackException` of type `TYPE_UNEXPECTED`, which surfaces the **"Unexpected playback error null"** toast and forces a full engine restart.

With this change, `MediaCodecRenderer.render()` catches the transient decoder fault and **re-initializes the codec in place**, so playback continues instead of tearing down the player. The approach mirrors how newer ExoPlayer/Media3 recovers from codec faults, but the code here is written against this fork's own existing `releaseCodec()` / `maybeInitCodec()` primitives — it is not a cherry-pick of a specific upstream commit.

## What changed

- `MediaCodecRenderer.render()` wraps the drain/feed loop; a MediaCodec-originated `IllegalStateException` triggers in-place codec re-init rather than propagating.
- A **time-windowed 3-strike budget** (`MAX_CODEC_RECOVERY_ATTEMPTS` within `CODEC_RECOVERY_WINDOW_MS`) prevents a permanently wedged codec from reinit-looping; once exhausted, the error is surfaced with a real, descriptive message instead of a bare `null`.
- Recovery tolerates `releaseCodec()` itself throwing on a wedged codec (its `stop()` can throw), because the `finally` has already nulled the codec — so `maybeInitCodec()` still runs.
- The unrecoverable fallback reports `TYPE_UNEXPECTED` (not `TYPE_RENDERER`) **on purpose**: a renderer-typed error causes the app to persist `VIDEO_FHD_AVC_30`, wiping the user's video-quality preset. `TYPE_UNEXPECTED` preserves the existing non-destructive restart path while replacing the `null` message with a meaningful one.

## Error classification

Only genuine MediaCodec faults are recovered — the gate checks for `MediaCodec.CodecException` (API 21+) or an `IllegalStateException` whose top stack frame is `android.media.MediaCodec`. Unrelated `IllegalStateException`s are rethrown unchanged.

## Testing

- Added a plain-JUnit test (`MediaCodecRendererTest`) covering the error-classification gate. It is deliberately **not** Robolectric-based: the bundled 2019-era Robolectric cannot run under the JDK 17 that the app build now requires, so the existing Robolectric suite is inert under current tooling.
- Dogfooded on-device (Android TV, hardware VP9) across multi-day real playback: the fault now recovers in place with a brief (~50ms) hitch instead of the previous toast + full restart + preset wipe.

## Scope

Two files, `+199 / -3`:
- `exoplayer-amzn-2.10.6/.../mediacodec/MediaCodecRenderer.java`
- `exoplayer-amzn-2.10.6/.../mediacodec/MediaCodecRendererTest.java` (new)

No changes to app modules; no new dependencies.

---

This is my first pull request to this project, so I welcome any feedback.
