### PR TITLE
Handle malformed SABR CDN candidates

### DIFF
--- a/exoplayer-amzn-2.10.6/library/sabr/src/main/java/com/google/android/exoplayer2/source/sabr/manifest/SabrCdnSelector.java
+++ b/exoplayer-amzn-2.10.6/library/sabr/src/main/java/com/google/android/exoplayer2/source/sabr/manifest/SabrCdnSelector.java
@@ -96,20 +96,14 @@ final class SabrCdnSelector {
     }
 
     private int findCandidateIndex(@Nullable String url) {
-        if (url == null) {
-            return -1;
-        }
+        String failedHost = getHost(url);
 
-        String failedHost;
-
-        try {
-            failedHost = URI.create(url).getHost();
-        } catch (IllegalArgumentException e) {
+        if (failedHost == null) {
             return -1;
         }
 
         for (int i = 0; i < candidateUrls.size(); i++) {
-            String candidateHost = URI.create(candidateUrls.get(i)).getHost();
+            String candidateHost = getHost(candidateUrls.get(i));
 
             if (candidateHost != null && candidateHost.equalsIgnoreCase(failedHost)) {
                 return i;
@@ -117,6 +111,18 @@ final class SabrCdnSelector {
         }
 
         return -1;
+    }
+
+    private static @Nullable String getHost(@Nullable String url) {
+        if (url == null) {
+            return null;
+        }
+
+        try {
+            return URI.create(url).getHost();
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
     private static @Nullable String extractNetwork(@Nullable String host) {

--- a/exoplayer-amzn-2.10.6/library/sabr/src/test/java/com/google/android/exoplayer2/source/sabr/manifest/SabrCdnSelectorTest.java
+++ b/exoplayer-amzn-2.10.6/library/sabr/src/test/java/com/google/android/exoplayer2/source/sabr/manifest/SabrCdnSelectorTest.java
@@ -60,6 +60,15 @@ public class SabrCdnSelectorTest {
     }
 
     @Test
+    public void malformedCandidateIsIgnoredDuringFailureHandling() {
+        String malformedUrl = "https://rr1---sn-primary.googlevideo.com/%";
+        SabrCdnSelector selector = new SabrCdnSelector(malformedUrl);
+
+        assertFalse(selector.maybeAdvance(PRIMARY_URL));
+        assertEquals(malformedUrl, selector.getCurrentUrl());
+    }
+
+    @Test
     public void urlWithoutMatchingNetworkHasNoFallback() {
         String url = "https://rr1---sn-other.googlevideo.com/videoplayback?"
                 + "mn=sn-primary%2Csn-secondary";


### PR DESCRIPTION
The main CDN failover from this PR is now in master as ff50afbfc. Thanks for adding it.

This leaves the small defensive follow-up found during review. findCandidateIndex reparsed each stored candidate without guarding URI.create, so an invalid stored URL combined with a valid failed URL could throw while handling the original playback error. Both the failed URL and stored candidates now use the same guarded host parser and treat malformed values as non-matches.

A regression test covers the malformed-candidate case. The focused SabrCdnSelector test suite passes.

The branch has been rebased onto current master and now contains only this one Jupiops-authored follow-up commit.