### PR TITLE
player: add 1.35x, 1.45x, 1.6x, 1.8x intermediate playback speed presets

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/utils/Utils.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/utils/Utils.java
@@ -139,7 +139,7 @@ public class Utils {
     private static final String GLOBAL_VOLUME_SERVICE = Context.AUDIO_SERVICE;
     public static final Handler sHandler = new Handler(Looper.getMainLooper());
     public static final float[] SPEED_LIST_LONG =
-            new float[]{0.25f, 0.5f, 0.75f, 0.80f, 0.85f, 0.90f, 0.95f, 1.0f, 1.05f, 1.1f, 1.15f, 1.2f, 1.25f, 1.3f, 1.4f, 1.5f, 1.75f, 2f, 2.25f, 2.5f, 2.75f, 3.0f, 3.25f, 3.5f, 3.75f, 4.0f};
+            new float[]{0.25f, 0.5f, 0.75f, 0.80f, 0.85f, 0.90f, 0.95f, 1.0f, 1.05f, 1.1f, 1.15f, 1.2f, 1.25f, 1.3f, 1.35f, 1.4f, 1.45f, 1.5f, 1.6f, 1.75f, 1.8f, 2.0f, 2.25f, 2.5f, 2.75f, 3.0f, 3.25f, 3.5f, 3.75f, 4.0f};
     public static final float[] SPEED_LIST_EXTRA_LONG = Helpers.range(0.05f, 4f, 0.05f);
     public static final float[] SPEED_LIST_SHORT =
             new float[] {0.25f, 0.5f, 0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f, 2.25f, 2.5f, 2.75f, 3.0f, 3.25f, 3.5f, 3.75f, 4.0f};


### PR DESCRIPTION
### Summary
Adds popular intermediate playback speed presets (`1.35x`, `1.45x`, `1.60x`, `1.80x`) to the long speed list (`SPEED_LIST_LONG`).

### Motivation
In `SPEED_LIST_LONG`, speed steps increase in 0.05 increments up to 1.30x, but then abruptly jump to 1.40x, 1.50x, 1.75x, and 2.00x. Adding `1.35x`, `1.45x`, `1.60x`, and `1.80x` provides a smoother stepping progression for users watching podcasts and lectures on Android TV remotes without having to enable the 80-item extra-long list.

### Changes
- Updated `Utils.SPEED_LIST_LONG` in `Utils.java`.
