### PR TITLE
i18n: update traditional chinese strings

### DIFF
--- a/common/src/main/res/values-zh-rTW/strings.xml
+++ b/common/src/main/res/values-zh-rTW/strings.xml
@@ -731,4 +731,21 @@
   <string name="add_video_to_watch_later">添加到稍後觀看</string>
   <string name="remove_video_to_watch_later">從稍後觀看中移除</string>
   <string name="network_settings">網路設定</string>
+  <string name="player_time_stretching">音訊時間伸展</string>
+  <string name="player_time_stretching_desc">變速時保持語音自然。可能會顯著降低某些裝置的效能。</string>
+  <string name="queue_respects_playback_mode">佇列遵循播放模式</string>
+  <string name="ignore_short_segments">忽略簡短片段</string>
+  <string name="install_bridge">安裝 ATV/Amazon 橋接器</string>
+  <string name="fix_empty_subs_and_channels">修復空白訂閱和頻道</string>
+  <string name="local_backup_not_supported">由於系統限制，Android TV 11 及以上版本不支援本機自動備份。請改用 Google 雲端硬碟。</string>
+  <string name="sidebar_notification">在側邊欄顯示通知</string>
+  <string name="rounded_card_corners">圓角卡片</string>
+  <string name="color_scheme_dark_blue_oled">深藍（OLED）</string>
+  <string name="player_unexpected_error">非預期的播放錯誤</string>
+  <string name="app_backup_desc">注意：備份檔案將以 zip 格式建立。</string>
+  <string name="app_restore_desc">注意：備份的 zip 壓縮檔需手動複製到此資料夾，或在檔案管理器中使用「開啟方式」選項。</string>
+  <string name="remove_from_search_history">從搜尋紀錄中移除</string>
+  <string name="enable_conscrypt">啟用 Conscrypt</string>
+  <string name="enable_conscrypt_desc">改進某些裝置 HTTPS、TLS 和 VPN 的相容性，但偶爾可能會導致播放問題或降低網路效能</string>
+  <string name="comments_disabled">此影片已關閉留言</string>
 </resources>


### PR DESCRIPTION
### Summary
Adds missing Traditional Chinese (`values-zh-rTW`) translation strings to match recent features and settings.

### Strings Added
- `player_time_stretching` & `player_time_stretching_desc`
- `queue_respects_playback_mode`
- `ignore_short_segments`
- `install_bridge`
- `fix_empty_subs_and_channels`
- `local_backup_not_supported`
- `sidebar_notification`
- `rounded_card_corners`
- `color_scheme_dark_blue_oled`
- `player_unexpected_error`
- `app_backup_desc` & `app_restore_desc`
- `remove_from_search_history`
- `enable_conscrypt` & `enable_conscrypt_desc`
- `comments_disabled`
