### PR TITLE
player: fix uninitialized timestamp in buffering detector

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/misc/BufferingDetector.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/misc/BufferingDetector.java
@@ -30,13 +30,17 @@ public class BufferingDetector {
             mTotalDurationMs = 0;
         }
         mStartTimeMs = currentTimeMs;
-        Utils.postDelayed(mOnLongBuffering, BUFFERING_DURATION_MS - mTotalDurationMs);
+        long delayMs = Math.max(0, BUFFERING_DURATION_MS - mTotalDurationMs);
+        Utils.postDelayed(mOnLongBuffering, delayMs);
     }
 
     public void onStopBuffering() {
         Utils.removeCallbacks(mOnLongBuffering);
-        long stopTimeMs = System.currentTimeMillis();
-        mTotalDurationMs += (stopTimeMs - mStartTimeMs);
+        if (mStartTimeMs > 0) {
+            long stopTimeMs = System.currentTimeMillis();
+            mTotalDurationMs += (stopTimeMs - mStartTimeMs);
+            mStartTimeMs = 0;
+        }
         mIsPlayable = true;
     }
 


### PR DESCRIPTION
### Summary
Fixes an uninitialized timestamp calculation in `BufferingDetector` that could lead to false-positive long buffering events and premature QoS recovery actions.

### Problem
When `onStopBuffering()` is invoked before any `onStartBuffering()` call (e.g. during initial playback startup), `mStartTimeMs` is `0`. Subtracting `0` from `System.currentTimeMillis()` corrupted `mTotalDurationMs` with a massive value (~1.7 trillion ms). Subsequently, `onStartBuffering()` passed a negative delay to `postDelayed()`, triggering `onLongBuffering()` immediately and causing unexpected resolution drops or engine restarts.

### Solution
1. Only accumulate `mTotalDurationMs` in `onStopBuffering()` if `mStartTimeMs > 0`, and reset `mStartTimeMs` to `0`.
2. Guard the calculated delay in `onStartBuffering()` with `Math.max(0, ...)` to prevent negative delays.
