### PR TITLE
player: stop endless reload on format info errors

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/ErrorFixerController.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/ErrorFixerController.java
@@ -22,8 +22,11 @@ import java.util.List;
 public class ErrorFixerController extends BasePlayerController implements OnLongBuffering {
     private static final String TAG = ErrorFixerController.class.getSimpleName();
     private static final long STREAM_END_THRESHOLD_MS = 180_000;
+    private static final int MAX_FORMAT_RELOAD_NUM = 3;
     private final BufferingDetector mBufferingDetector = new BufferingDetector(this);
     private VideoLoaderController mVideoLoaderController;
+    private String mFormatErrorVideoId;
+    private int mFormatErrorNum;
 
     @Override
     public void onInit() {
@@ -92,6 +95,18 @@ public class ErrorFixerController extends BasePlayerController implements OnLong
     @Override
     public void onNewVideo(Video item) {
         mBufferingDetector.start();
+
+        // NOTE: reloadVideo() fires onNewVideo() with the same item, so compare the ids
+        String videoId = item != null ? item.videoId : null;
+        if (!Helpers.equals(videoId, mFormatErrorVideoId)) {
+            mFormatErrorVideoId = videoId;
+            mFormatErrorNum = 0;
+        }
+    }
+
+    @Override
+    public void onVideoLoaded(Video item) {
+        mFormatErrorNum = 0;
     }
 
     @Override
@@ -102,6 +117,8 @@ public class ErrorFixerController extends BasePlayerController implements OnLong
     @Override
     public void onEngineReleased() {
         mBufferingDetector.reset();
+        mFormatErrorVideoId = null;
+        mFormatErrorNum = 0;
     }
 
     private void runEngineErrorAction(int type, int rendererIndex, Throwable error) {
@@ -305,6 +322,14 @@ public class ErrorFixerController extends BasePlayerController implements OnLong
             return;
         }
 
+        // Don't reload the same video endlessly. Some videos can't be played at all
+        // (e.g. members only content) and the reload below produces an infinite loading spinner.
+        if (++mFormatErrorNum > MAX_FORMAT_RELOAD_NUM) {
+            Log.e(TAG, "Can't load the video after %s attempts. Giving up...", MAX_FORMAT_RELOAD_NUM);
+            showFormatError();
+            return;
+        }
+
         if (Helpers.containsAny(message, "Unexpected token", "Syntax error", "invalid argument") || // temporal fix
                 Helpers.equalsAny(className, "PoTokenException", "BadWebViewException")) {
             YouTubeServiceManager.instance().applyNoPlaybackFix();
@@ -316,6 +341,22 @@ public class ErrorFixerController extends BasePlayerController implements OnLong
             Log.e(TAG, "Probably no internet connection");
             mVideoLoaderController.reloadVideo();
         }
+    }
+
+    /**
+     * Stop the loading indicator and tell the user why nothing is playing.
+     */
+    private void showFormatError() {
+        if (getPlayer() == null) {
+            return;
+        }
+
+        String errorMessage = getContext().getString(R.string.msg_player_error_source);
+
+        getPlayer().showProgressBar(false);
+        getPlayer().setTitle(errorMessage);
+        getPlayer().showOverlay(true);
+        MessageHelpers.showLongMessage(getContext(), errorMessage);
     }
 
     /**


### PR DESCRIPTION
## Problem

Clicking a members only video produces an endless loading spinner - no message, no error, playback never starts. The spinner briefly blinks off roughly once a second and comes back.

`ErrorFixerController.runFormatErrorAction()` ends with an unconditional `mVideoLoaderController.reloadVideo()` and there is no attempt counter. The toast is also suppressed for `"fromNullable result is null"`, which is exactly the error raised when the format info comes back empty. So when a video genuinely cannot produce format info, the result is a silent infinite loop:

```
loadVideo -> showProgressBar(true) -> getFormatInfoObserve
  -> onError("fromNullable result is null")
  -> showProgressBar(false) -> runFormatErrorAction -> reloadVideo(1s)
  -> onNewVideo(same video) -> loadVideo -> ...
```

## Change

Cap the consecutive reloads for the same video. After the limit, hide the progress bar, put the error on screen via `setTitle` + `showOverlay`, show a message, and stop.

The counter resets when the video actually changes (`reloadVideo()` re-fires `onNewVideo()` with the same item, so the ids are compared rather than the objects), when a video successfully loads, and when the engine is released - so a genuinely transient failure still gets its retries, and reopening a video later starts fresh.

Reuses the existing `msg_player_error_source` string, so no new translations.

## Scope

This bounds the loop for any cause. The root cause behind the members only case lives in MediaServiceCore and is handled separately in yuliskov/MediaServiceCore#32 - with that change the app gets a proper unplayable response and shows the real playability reason instead of erroring at all. This change is still worth having on its own, since the same silent loop happens whenever format info can't be fetched (no network, all clients failing).

No submodule pointer bump here - that should follow once the MediaServiceCore side lands.

## Testing

**Not tested on a device** - I don't have a build environment set up for this repo, which is why this is a draft. Reviewed by reading the call graph. Worth confirming: `RxHelper` delivers the error via `observeOn(AndroidSchedulers.mainThread())`, so it always arrives after the synchronous `onNewVideo` dispatch and cannot race the counter reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtUccbY1niFoszZPv6jJqp
