### PR TITLE
feat: handle KEYCODE_NUMPAD_ENTER as DPAD_CENTER

### DIFF
--- a/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/tv/ui/mod/leanback/playerglue/tweaks/PlaybackTransportRowPresenter.java
+++ b/smarttubetv/src/main/java/com/liskovsoft/smartyoutubetv2/tv/ui/mod/leanback/playerglue/tweaks/PlaybackTransportRowPresenter.java
@@ -508,6 +508,7 @@ public class PlaybackTransportRowPresenter extends PlaybackRowPresenter {
                         //case KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE: // MOD: act as OK? (handled somewhere else, inside player glue)
                         case KeyEvent.KEYCODE_DPAD_CENTER:
                         case KeyEvent.KEYCODE_ENTER:
+                        case KeyEvent.KEYCODE_NUMPAD_ENTER:
                             if (!mInSeek) {
                                 return false; // use pause toggle handler
                             }


### PR DESCRIPTION
Fixes center/select button for Fire TV and generic Bluetooth remotes mapped as KEYCODE_NUMPAD_ENTER on standard Android TV.