### PR TITLE
player: add option to auto-hide UI when paused

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/PlayerUIController.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/PlayerUIController.java
@@ -71,14 +71,17 @@ public class PlayerUIController extends BasePlayerController {
             return;
         }
 
-        // Playing the video and dialog overlay isn't shown
-        if (getPlayer().isPlaying() && !getAppDialogPresenter().isDialogShown()) {
+        boolean canHide = (getPlayer().isPlaying() || getPlayerTweaksData().isAutoHideUiWhenPausedEnabled())
+                && !getAppDialogPresenter().isDialogShown();
+
+        // Playing the video (or auto-hide on pause enabled) and dialog overlay isn't shown
+        if (canHide) {
             if (getPlayer().isControlsShown()) { // don't hide when suggestions is shown
                 getPlayer().showOverlay(false);
                 mOverlayHideTimeMs = System.currentTimeMillis();
             }
         } else {
-            // in seeking state? doing recheck...
+            // in seeking state or paused with hide disabled? doing recheck...
             enableUiAutoHideTimeout();
         }
     };

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/settings/PlayerSettingsPresenter.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/settings/PlayerSettingsPresenter.java
@@ -486,6 +486,11 @@ public class PlayerSettingsPresenter extends BasePresenter<Void> {
                 option -> mPlayerTweaksData.setQueueRespectsPlaybackMode(option.isSelected()),
                 mPlayerTweaksData.isQueueRespectsPlaybackMode()));
 
+        options.add(UiOptionItem.from(getContext().getString(R.string.auto_hide_ui_when_paused),
+                getContext().getString(R.string.auto_hide_ui_when_paused_desc),
+                option -> mPlayerTweaksData.setAutoHideUiWhenPausedEnabled(option.isSelected()),
+                mPlayerTweaksData.isAutoHideUiWhenPausedEnabled()));
+
         settingsPresenter.appendCheckedCategory(getContext().getString(R.string.player_other), options);
     }
 

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/prefs/PlayerTweaksData.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/prefs/PlayerTweaksData.java
@@ -109,6 +109,7 @@ public class PlayerTweaksData implements ProfileChangeListener {
     private boolean mIsDontResizeVideoToFitDialogEnabled;
     private boolean mIsSuggestionsHorizontallyScrolled;
     private boolean mIsQueueRespectsPlaybackMode;
+    private boolean mIsAutoHideUiWhenPausedEnabled;
     private final Runnable mPersistDataInt = this::persistDataInt;
 
     private PlayerTweaksData(Context context) {
@@ -691,6 +692,15 @@ public class PlayerTweaksData implements ProfileChangeListener {
         persistData();
     }
 
+    public boolean isAutoHideUiWhenPausedEnabled() {
+        return mIsAutoHideUiWhenPausedEnabled;
+    }
+
+    public void setAutoHideUiWhenPausedEnabled(boolean enable) {
+        mIsAutoHideUiWhenPausedEnabled = enable;
+        persistData();
+    }
+
     private void restoreData() {
         String data = mPrefs.getProfileData(VIDEO_PLAYER_TWEAKS_DATA);
 
@@ -762,6 +772,7 @@ public class PlayerTweaksData implements ProfileChangeListener {
         mIsQuickSkipVideosAltEnabled = Helpers.parseBoolean(split, 58, false);
         mIsAudioTimeStretchingEnabled = Helpers.parseBoolean(split, 59, true);
         mIsQueueRespectsPlaybackMode = Helpers.parseBoolean(split, 60, false);
+        mIsAutoHideUiWhenPausedEnabled = Helpers.parseBoolean(split, 61, false);
 
         updateDefaultValues();
     }
@@ -789,7 +800,8 @@ public class PlayerTweaksData implements ProfileChangeListener {
                 mIsUnsafeAudioFormatsEnabled, null, mIsLoopShortsEnabled, mIsQuickSkipShortsEnabled, mIsRememberPositionOfLiveVideosEnabled,
                 mIsOculusQuestFixEnabled, null, mIsExtraLongSpeedListEnabled, mIsQuickSkipVideosEnabled, mIsNetworkErrorFixingDisabled, mIsCommentsPlacedLeft,
                 null, mIsAudioFocusEnabled, mIsDontResizeVideoToFitDialogEnabled, mIsSuggestionsHorizontallyScrolled,
-                mIsQuickSkipShortsAltEnabled, mIsQuickSkipVideosAltEnabled, mIsAudioTimeStretchingEnabled, mIsQueueRespectsPlaybackMode
+                mIsQuickSkipShortsAltEnabled, mIsQuickSkipVideosAltEnabled, mIsAudioTimeStretchingEnabled, mIsQueueRespectsPlaybackMode,
+                mIsAutoHideUiWhenPausedEnabled
                 ));
     }
 

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -86,6 +86,8 @@
     <string name="update_not_found">You\'re using the latest version</string>
     <string name="update_in_progress">Wait…</string>
     <string name="player_ui_hide_behavior">Auto-hide UI</string>
+    <string name="auto_hide_ui_when_paused">Auto-hide UI when paused</string>
+    <string name="auto_hide_ui_when_paused_desc">Automatically hides playback controls after timeout even while playback is paused to prevent OLED screen burn-in</string>
     <string name="option_never">Never</string>
     <string name="side_panel_sections">Set-up sections</string>
     <string name="boot_to_section">Boot to section</string>


### PR DESCRIPTION
### Summary
Adds an optional setting under **Settings → Player → Other** to automatically hide the player controls/OSD overlay after the configured timeout even while playback is paused.

### Motivation
By default, player transport controls remain permanently on screen when playback is paused. For users with OLED TVs or users who pause videos to view background frames/art without UI clutter, this setting allows the overlay to auto-hide while paused, protecting displays from static UI burn-in.

### Changes
1. **PlayerTweaksData**: Added `isAutoHideUiWhenPausedEnabled()` preference (persisted at index 61).
2. **PlayerUIController**: Updated `mUiAutoHideHandler` to allow overlay dismissal when paused if enabled.
3. **PlayerSettingsPresenter**: Added `Auto-hide UI when paused` checkbox option.
4. **strings.xml**: Added string resources and description.
