### PR TITLE
afr: fix window display mode reset handling when modeId is 0

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/autoframerate/internal/UhdHelper.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/autoframerate/internal/UhdHelper.java
@@ -340,7 +340,18 @@ public class UhdHelper {
      */
     @TargetApi(17)
     public void setPreferredDisplayModeId(Window targetWindow, int modeId, boolean allowOverlayDisplay) {
-        if (modeId == 0) { // mode is not set
+        if (modeId == 0) { // reset mode
+            if (targetWindow != null) {
+                try {
+                    WindowManager.LayoutParams layoutParams = targetWindow.getAttributes();
+                    Class<?> cLayoutParams = layoutParams.getClass();
+                    Field attributeFlags = cLayoutParams.getDeclaredField(sPreferredDisplayModeIdFieldName);
+                    attributeFlags.setInt(layoutParams, 0);
+                    targetWindow.setAttributes(layoutParams);
+                } catch (Exception e) {
+                    Log.e(TAG, "error resetting mode", e);
+                }
+            }
             return;
         }
 


### PR DESCRIPTION
### Summary
Fixes `UhdHelper.setPreferredDisplayModeId()` when called with `modeId = 0` (`resetMode`).

### Changes
- Ensures `layoutParams.preferredDisplayModeId` is explicitly cleared to `0` and applied to the target window on exit instead of returning early without updating layout attributes.
