### PR TITLE
audio: improve 5.1/7.1 surround channel count detection

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/exoplayer/selector/TrackSelectorUtil.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/exoplayer/selector/TrackSelectorUtil.java
@@ -205,7 +205,17 @@ public class TrackSelectorUtil {
     }
 
     public static String buildChannels(Format format) {
-        return is51Audio(format) ? "5.1" : "";
+        if (format == null) {
+            return "";
+        }
+
+        if (format.channelCount == 8) {
+            return "7.1";
+        } else if (format.channelCount == 6 || is51Audio(format)) {
+            return "5.1";
+        }
+
+        return "";
     }
 
     public static String buildDrcMark(Format format) {
@@ -221,7 +231,7 @@ public class TrackSelectorUtil {
             return false;
         }
 
-        return format.bitrate > 300000;
+        return (format.channelCount != Format.NO_VALUE && format.channelCount >= 6) || format.bitrate > 300000;
     }
 
     public static boolean is48KAudio(Format format) {


### PR DESCRIPTION
### Summary
Enhances surround track identification in `TrackSelectorUtil`.

### Changes
- Checks `format.channelCount >= 6` in `is51Audio()` rather than solely relying on bitrate thresholds (>300kbps), correctly identifying compressed Opus 5.1 and EAC3 streams.
- Adds 7.1 channel badge formatting support in `buildChannels()`.
