### PR TITLE
Reduce regular video startup latency

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/SplashPresenter.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/SplashPresenter.java
@@ -91,6 +91,7 @@ public class SplashPresenter extends BasePresenter<SplashView> {
             RxHelper.setupGlobalErrorHandler();
             initGlobalPrefs();
             initProxy();
+            YouTubeServiceManager.instance().warmUpPlaybackToken();
             initVideoStateService();
             initStreamReminderService();
         }

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/SplashPresenter.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/SplashPresenter.java
@@ -91,7 +91,7 @@ public class SplashPresenter extends BasePresenter<SplashView> {
             RxHelper.setupGlobalErrorHandler();
             initGlobalPrefs();
             initProxy();
-            YouTubeServiceManager.instance().warmUpPlaybackToken();
+            YouTubeServiceManager.warmUpPlaybackToken();
             initVideoStateService();
             initStreamReminderService();
         }

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/dialogs/VideoActionPresenter.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/dialogs/VideoActionPresenter.java
@@ -29,6 +29,9 @@ public class VideoActionPresenter extends BasePresenter<Void> {
 
         // Show playlist contents in channel instead of instant playback
         if (item.hasVideo() && !item.isBadgePlaylistInChannel()) {
+            // Resolve formats while the playback activity is being created. The media service
+            // shares this in-flight request with the player, so it does not duplicate work.
+            MediaServiceManager.instance().loadFormatInfo(item, formatInfo -> {});
             PlaybackPresenter.instance(getContext()).openVideo(item);
         } else if (item.hasChannel() || (item.belongsToChannelUploads() && item.hasNestedItems())) {
             MediaServiceManager.chooseChannelPresenter(getContext(), item);

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/dialogs/VideoActionPresenter.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/presenters/dialogs/VideoActionPresenter.java
@@ -29,9 +29,9 @@ public class VideoActionPresenter extends BasePresenter<Void> {
 
         // Show playlist contents in channel instead of instant playback
         if (item.hasVideo() && !item.isBadgePlaylistInChannel()) {
-            // Resolve formats while the playback activity is being created. The media service
-            // shares this in-flight request with the player, so it does not duplicate work.
-            MediaServiceManager.instance().loadFormatInfo(item, formatInfo -> {});
+            // Resolve formats while the playback activity is being created without interrupting
+            // format loads owned by menus or other UI flows.
+            MediaServiceManager.instance().prefetchFormatInfo(item);
             PlaybackPresenter.instance(getContext()).openVideo(item);
         } else if (item.hasChannel() || (item.belongsToChannelUploads() && item.hasNestedItems())) {
             MediaServiceManager.chooseChannelPresenter(getContext(), item);

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/exoplayer/other/ExoPlayerInitializer.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/exoplayer/other/ExoPlayerInitializer.java
@@ -109,7 +109,9 @@ public class ExoPlayerInitializer {
         // Default values
         int minBufferMs = 30_000;
         int maxBufferMs = 30_000;
-        int bufferForPlaybackMs = 2_500;
+        // Reduce initial wait without changing the conservative rebuffer threshold used by
+        // high-bitrate streams.
+        int bufferForPlaybackMs = 1_500;
         int bufferForPlaybackAfterRebufferMs = 5_000;
 
         switch (mPlayerData.getVideoBufferType()) {

--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/misc/MediaServiceManager.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/misc/MediaServiceManager.java
@@ -260,6 +260,22 @@ public class MediaServiceManager implements OnAccountChange {
                 );
     }
 
+    /**
+     * Starts format resolution without replacing the action owned by loadFormatInfo.
+     * The media service shares an in-flight request for the same video with playback.
+     */
+    public void prefetchFormatInfo(Video item) {
+        if (item == null) {
+            return;
+        }
+
+        mItemService.getFormatInfoObserve(item.videoId)
+                .subscribe(
+                        formatInfo -> { },
+                        error -> Log.e(TAG, "prefetchFormatInfo error: %s", error.getMessage())
+                );
+    }
+
     public void loadPlaylists(Video item, OnMediaGroup onPlaylistGroup) {
         if (item == null) {
             return;


### PR DESCRIPTION
Starts format resolution while the player activity opens and lowers only the initial buffer threshold from 2.5 seconds to 1.5 seconds; rebuffer behavior is unchanged. Depends on the MediaServiceCore playback-token change: https://github.com/yuliskov/MediaServiceCore/pull/34. Tested on an Android TV build while retaining 4K/AV1, live streams, captions, SponsorBlock, seeking, profiles, and quality switching.