### PR TITLE
Include x86 native libs in the universal APK (fixes playback hang on Android-x86)

### DIFF
--- a/smarttubetv/build.gradle
+++ b/smarttubetv/build.gradle
@@ -71,7 +71,12 @@ android {
 
         // The content of Universal apk
         ndk {
-            abiFilters 'armeabi-v7a', 'arm64-v8a'
+            // Must list every ABI built by the splits block below, otherwise the
+            // universal APK ships no native libs for the missing ones. Devices
+            // running Android-x86 (and other x86 targets) then fall back to
+            // translating the ARM libj2v8.so, which cannot JIT and hangs the
+            // nsig challenge solver, leaving playback stuck on a spinner forever.
+            abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86'
         }
     }
 


### PR DESCRIPTION
## Problem

`smarttubetv/build.gradle` builds an x86 split APK, but restricts the **universal** APK to ARM only:

```gradle
ndk {
    abiFilters 'armeabi-v7a', 'arm64-v8a'   // universal APK contents
}
splits { abi {
    include 'armeabi-v7a', 'arm64-v8a', 'x86'
    universalApk true
}}
```

The universal APK is what most users install, so on x86 Android it ships **no x86 native libraries**.

## Symptom

Playback hangs on an infinite spinner and the home feed stays empty. There is no error and no timeout — the last log line is:

```
D/nativeloader: Load .../lib/arm64/libj2v8.so ... ok
D/JsRuntimeChalBaseJCP: Using challenge solver lib script v0.0.1 (variant: v8_npm)
D/JsRuntimeChalBaseJCP: Using challenge solver core script v0.0.1
   <- nothing after this, ever
```

## Cause

With no x86 libs, the device loads the **arm64** `libj2v8.so` through `libhoudini`. J2V8 is the V8 engine and JITs native code at runtime, which binary translation cannot do reliably, so `nsigsolver` never returns. Without descrambled stream URLs there is nothing to play.

Everything else works fine — PoToken/BotGuard succeeds, because that path runs in WebView's own native V8 rather than J2V8.

## Verification

Android-x86 14, x86_64 (Lenovo ThinkCentre M70q Gen 2), SmartTube 32.38:

| APK | Result |
|---|---|
| `SmartTube_stable_32.38_universal.apk` | hangs at the solver, spinner forever |
| `SmartTube_stable_32.38_x86.apk` | plays normally |

Same device, same version, same network. Installing the x86 split fixed it, confirming the ABI is the only variable. Reinstalling the universal APK with `pm install --abi armeabi-v7a` hangs identically, so it is not ABI *selection* — the x86 libs simply are not present.

## Fix

Add `'x86'` to `ndk.abiFilters` so the universal APK carries the x86 libraries that the splits block already builds successfully.

## Note on x86_64

I did not add `x86_64`. The splits block has it commented out, and I could not verify that x86_64 binaries exist for `libj2v8` / `libcronet` / `libconscrypt_jni` in the dependency setup — declaring an ABI with no libs behind it would be worse than the current state. Happy to add it if those are available.
