### PR TITLE
player error fixer: bounded retry + clear error on bot-blocked playback

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/ErrorFixerController.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/ErrorFixerController.java
@@ -22,8 +22,11 @@ import java.util.List;
 public class ErrorFixerController extends BasePlayerController implements OnLongBuffering {
     private static final String TAG = ErrorFixerController.class.getSimpleName();
     private static final long STREAM_END_THRESHOLD_MS = 180_000;
+    private static final int MAX_BOT_BLOCK_RETRIES = 3;
     private final BufferingDetector mBufferingDetector = new BufferingDetector(this);
     private VideoLoaderController mVideoLoaderController;
+    private String mBotBlockedVideoId;
+    private int mBotBlockRetryCount;
 
     @Override
     public void onInit() {
@@ -105,8 +108,15 @@ public class ErrorFixerController extends BasePlayerController implements OnLong
     }
 
     @Override
+    public void onVideoLoaded(Video item) {
+        // Successful playback clears any pending bot-block retry state.
+        resetBotBlockRetry();
+    }
+
+    @Override
     public void onFinish() {
         mBufferingDetector.reset();
+        resetBotBlockRetry();
     }
 
     @Override
@@ -326,10 +336,62 @@ public class ErrorFixerController extends BasePlayerController implements OnLong
         } else if (Helpers.containsAny(message, "is not defined")) {
             YouTubeServiceManager.instance().invalidateCache();
             mVideoLoaderController.reloadVideo();
+        } else if (isBotBlocked(message)) {
+            runBotBlockRetry();
         } else {
             Log.e(TAG, "Probably no internet connection");
             mVideoLoaderController.reloadVideo();
         }
+    }
+
+    private boolean isBotBlocked(String message) {
+        // YouTube returned no playable format (e.g. LOGIN_REQUIRED "Sign in to confirm that you're not a bot").
+        // RxHelper reports the empty result as "fromNullable result is null".
+        return Helpers.containsAny(message, "fromNullable result is null");
+    }
+
+    private void runBotBlockRetry() {
+        String videoId = getVideo() != null ? getVideo().videoId : null;
+
+        if (!Helpers.equals(videoId, mBotBlockedVideoId)) {
+            mBotBlockedVideoId = videoId;
+            mBotBlockRetryCount = 0;
+        }
+
+        mBotBlockRetryCount++;
+
+        if (mBotBlockRetryCount > MAX_BOT_BLOCK_RETRIES) {
+            showPlaybackBlockedError();
+            return;
+        }
+
+        Log.e(TAG, "Playback blocked by YouTube. Retry %s/%s: switching client and refreshing poToken...",
+                mBotBlockRetryCount, MAX_BOT_BLOCK_RETRIES);
+
+        // Force a fresh poToken/visitor data and advance to the next client before retrying.
+        YouTubeServiceManager.instance().invalidateCache();      // resets poToken cache + resets client to default
+        YouTubeServiceManager.instance().switchNextClientNow();  // then advances to the next client
+
+        mVideoLoaderController.reloadVideo();
+    }
+
+    private void showPlaybackBlockedError() {
+        if (getPlayer() == null) {
+            return;
+        }
+
+        Log.e(TAG, "Giving up. Showing playback blocked error...");
+
+        String message = getContext().getString(R.string.msg_player_error_bot_blocked);
+        getPlayer().setTitle(message);
+        getPlayer().showProgressBar(false);
+        getPlayer().showOverlay(true);
+        MessageHelpers.showLongMessage(getContext(), message);
+    }
+
+    private void resetBotBlockRetry() {
+        mBotBlockedVideoId = null;
+        mBotBlockRetryCount = 0;
     }
 
     /**

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -221,6 +221,7 @@
     <string name="msg_player_error_audio_renderer">Selected AUDIO format isn\'t supported.\nTry to select another one by pressing HQ button in the player.\nIf this won\'t help try to reboot the device.</string>
     <string name="msg_player_error_subtitle_renderer">Selected SUBTITLE format isn\'t supported.\nTry to select another one by long pressing CC button in the player.\nIf this won\'t help try to reboot the device.</string>
     <string name="msg_player_error_unexpected">Unknown video decoder error</string>
+    <string name="msg_player_error_bot_blocked">Playback blocked by YouTube (possible IP/network flag). Try another network or VPN.</string>
     <string name="player_unexpected_error">Unexpected playback error</string>
     <string name="video_aspect">Aspect ratio</string>
     <string name="player_tweaks">Developer options</string>


### PR DESCRIPTION
## Problem

When YouTube flags an IP/network (e.g. a datacenter IP), every spoofed client returns `LOGIN_REQUIRED` ("Sign in to confirm that you're not a bot"). `VideoInfoService.getVideoInfo()` then returns null, which surfaces as an RxHelper error (`fromNullable result is null`), and playback hangs on a black screen with a spinner forever.

This is a known, widespread issue (related: #6030, #6063, #4287, #6067).

## What this changes

In `ErrorFixerController.runFormatErrorAction()`, when the error is `fromNullable result is null` (bot block), instead of falling through to the generic "probably no internet" reload loop forever:

- Retry up to 3 times, each time resetting the poToken cache (`invalidateCache()`) and advancing to the next client (`switchNextClientNow()`) before reloading.
- If still blocked after 3 tries, show a clear, localized message: "Playback blocked by YouTube (possible IP/network flag). Try another network or VPN." (new `msg_player_error_bot_blocked` string, added to `values/strings.xml` for Crowdin translation).

The retry state is reset when a video loads successfully (`onVideoLoaded`) or playback finishes (`onFinish`).

## Note

This is a UX safeguard, not a fix for the underlying IP flag — the existing workaround (a different network / VPN) still applies. It just stops the endless spinner and tells the user what's actually happening.