### PR TITLE
fix infinite loading caused by LOGIN_REQUIRED error

### DIFF
--- a/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/ErrorFixerController.java
+++ b/common/src/main/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/ErrorFixerController.java
@@ -16,6 +16,7 @@ import com.liskovsoft.smartyoutubetv2.common.prefs.PlayerData;
 import com.liskovsoft.smartyoutubetv2.common.prefs.PlayerTweaksData;
 import com.liskovsoft.smartyoutubetv2.common.utils.Utils;
 import com.liskovsoft.youtubeapi.service.YouTubeServiceManager;
+import com.liskovsoft.youtubeapi.videoinfo.LoginRequiredException;
 
 import java.util.List;
 
@@ -300,6 +301,20 @@ public class ErrorFixerController extends BasePlayerController implements OnLong
 
         if (isEmbedPlayer()) {
             getPlayer().finish();
+            return;
+        }
+
+        if (error instanceof LoginRequiredException) {
+            mBufferingDetector.reset();
+            String reason = error.getMessage();
+            if (reason == null || reason.trim().isEmpty()) {
+                reason = getContext().getString(R.string.action_signin);
+            }
+            Log.e(TAG, "Playback requires sign-in: %s", reason);
+            getPlayer().showProgressBar(false);
+            getPlayer().setTitle(reason);
+            getPlayer().showOverlay(true);
+            MessageHelpers.showLongMessage(getContext(), reason);
             return;
         }
 

--- a/common/src/test/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/ErrorFixerControllerTest.java
+++ b/common/src/test/java/com/liskovsoft/smartyoutubetv2/common/app/models/playback/controllers/ErrorFixerControllerTest.java
@@ -1,0 +1,38 @@
+package com.liskovsoft.smartyoutubetv2.common.app.models.playback.controllers;
+
+import com.liskovsoft.smartyoutubetv2.common.app.views.PlaybackView;
+import com.liskovsoft.youtubeapi.videoinfo.LoginRequiredException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import static org.junit.Assert.*;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE, sdk = 28)
+public class ErrorFixerControllerTest {
+    @Test public void signInRestrictionStopsLoadingAndShowsReasonWithoutReload() {
+        List<String> actions = new ArrayList<>();
+        String reason = "Sign in to confirm you're not a bot";
+        PlaybackView player = (PlaybackView) Proxy.newProxyInstance(
+                PlaybackView.class.getClassLoader(), new Class<?>[]{PlaybackView.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("isEmbed")) return false;
+                    actions.add(method.getName() + ":" + args[0]);
+                    return null;
+                });
+        ErrorFixerController controller = new ErrorFixerController() {
+            @Override public PlaybackView getPlayer() { return player; }
+        };
+
+        // No loader is attached: taking the old automatic reload path would fail this test.
+        controller.runFormatErrorAction(new LoginRequiredException(reason));
+        assertEquals(3, actions.size());
+        assertEquals("showProgressBar:false", actions.get(0));
+        assertEquals("setTitle:" + reason, actions.get(1));
+        assertEquals("showOverlay:true", actions.get(2));
+    }
+}


### PR DESCRIPTION
Required submodule PR: [MediaServiceCore](https://github.com/yuliskov/MediaServiceCore/pull/38)
---
Under some circumstances (like using a proxy server that would trigger bot checking by Google) Youtube returns LOGIN_REQUIRED response, which is not handled correctly and would cause infinite retrying (the user sees infinite loading).

```log
11:03:10.688 E YouTubeSignInService: Access token is null!

11:03:20.519 E VideoInfoService: Can't get video info. videoId: cR4EQ_dI1BM
11:03:20.522 E RxHelper: fromNullable result is null
11:03:20.523 E ErrorFixerController: loadFormatInfo error: IllegalStateException: fromNullable result is null
11:03:20.523 E ErrorFixerController: onError(RxHelper.java:351)
11:03:20.524 E ErrorFixerController: Probably no internet connection
11:03:20.524 D VideoLoaderController: Reloading the video...

11:03:30.622 E VideoInfoService: Can't get video info. videoId: cR4EQ_dI1BM
11:03:30.622 E RxHelper: fromNullable result is null
11:03:30.623 E ErrorFixerController: loadFormatInfo error: IllegalStateException: fromNullable result is null
11:03:30.623 E ErrorFixerController: Probably no internet connection
11:03:30.623 D VideoLoaderController: Reloading the video...
```

```json
{
  "playabilityStatus": {
    "status": "LOGIN_REQUIRED",
    "reason": "Sign in to confirm you are not a bot"
  }
}
```

After fixing, the user would see "Sign in to confirm you are not a bot" on the screen:

<img width="1920" height="1080" alt="screenshot-after" src="https://github.com/user-attachments/assets/6d9ebb5b-37a3-4957-9a15-30d3f0ace62d" />
