### PR TITLE
Fix SABR subtitle loading for external caption files

### DIFF
--- a/exoplayer-amzn-2.10.6/library/sabr/README.md
+++ b/exoplayer-amzn-2.10.6/library/sabr/README.md
@@ -4,6 +4,21 @@ Provides support for YouTube Dynamic Adaptive Streaming (SABR) content. To
 play SABR content, instantiate a `SabrMediaSource` and pass it to
 `ExoPlayer.prepare`.
 
+## Subtitles ##
+
+Subtitle tracks supplied by `MediaItemFormatInfo` are external caption files.
+They are fetched with an HTTP GET, including the manifest's visitor cookie when
+available, and loaded as a single sample covering the period. They must not be
+sent to the SABR endpoint or registered as SABR format selections. Audio and
+video continue to use SABR container requests.
+
+To run the module's regression tests from the repository root, use JDK 11 for
+compatibility with its Robolectric version:
+
+```sh
+JAVA_HOME=/path/to/jdk-11 bash ./gradlew :exoplayer-library-sabr:testStstableDebugUnitTest
+```
+
 ## Links ##
 
 * [Developer Guide][].

--- a/exoplayer-amzn-2.10.6/library/sabr/src/main/java/com/google/android/exoplayer2/source/sabr/DefaultSabrChunkSource.java
+++ b/exoplayer-amzn-2.10.6/library/sabr/src/main/java/com/google/android/exoplayer2/source/sabr/DefaultSabrChunkSource.java
@@ -20,6 +20,7 @@ import com.google.android.exoplayer2.source.chunk.ContainerMediaChunk;
 import com.google.android.exoplayer2.source.chunk.InitializationChunk;
 import com.google.android.exoplayer2.source.chunk.MediaChunk;
 import com.google.android.exoplayer2.source.chunk.MediaChunkIterator;
+import com.google.android.exoplayer2.source.chunk.SingleSampleMediaChunk;
 import com.google.android.exoplayer2.source.sabr.PlayerEmsgHandler.PlayerTrackEmsgHandler;
 import com.google.android.exoplayer2.source.sabr.manifest.AdaptationSet;
 import com.google.android.exoplayer2.source.sabr.manifest.RangedUri;
@@ -39,11 +40,13 @@ import com.google.android.exoplayer2.upstream.DataSpec;
 import com.google.android.exoplayer2.upstream.HttpDataSource.InvalidResponseCodeException;
 import com.google.android.exoplayer2.upstream.LoaderErrorThrower;
 import com.google.android.exoplayer2.upstream.TransferListener;
+import com.google.android.exoplayer2.util.Assertions;
 import com.google.android.exoplayer2.util.Log;
 import com.google.android.exoplayer2.util.MimeTypes;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -116,7 +119,7 @@ public class DefaultSabrChunkSource implements SabrChunkSource {
     private boolean missingLastSegment;
     private long liveEdgeTimeUs;
 
-    private final SabrStream sabrStream;
+    @Nullable private final SabrStream sabrStream;
     private final Map<String, String> sabrHeaders;
     private int nexChunkIdx = -1;
 
@@ -167,21 +170,20 @@ public class DefaultSabrChunkSource implements SabrChunkSource {
         long periodDurationUs = manifest.getPeriodDurationUs(periodIndex);
         liveEdgeTimeUs = C.TIME_UNSET;
         
-        this.sabrStream = manifest.getSabrStream(trackType);
-        //this.sabrStream.setAudioSelection(createAudioSelection(trackType, trackSelection));
-        //this.sabrStream.setVideoSelection(createVideoSelection(trackType, trackSelection));
-        //this.sabrStream.setCaptionSelection(createCaptionSelection(trackType, trackSelection));
-        this.sabrStream.setFormatSelector(formatSelector);
-
         sabrHeaders = new HashMap<>();
         sabrHeaders.put("Content-Type", "application/x-protobuf");
         //sabrHeaders.put("Accept-Encoding", "identity");
         sabrHeaders.put("Accept", "application/vnd.yt-ump");
 
         List<Representation> representations = getRepresentations();
+        SabrStream stream = null;
         representationHolders = new RepresentationHolder[trackSelection.length()];
         for (int i = 0; i < representationHolders.length; i++) {
             Representation representation = representations.get(trackSelection.getIndexInTrackGroup(i));
+            if (stream == null && RepresentationHolder.needsExtractor(representation)) {
+                stream = manifest.getSabrStream(trackType);
+                stream.setFormatSelector(formatSelector);
+            }
             representationHolders[i] =
                     new RepresentationHolder(
                             periodDurationUs,
@@ -190,8 +192,9 @@ public class DefaultSabrChunkSource implements SabrChunkSource {
                             enableEventMessageTrack,
                             closedCaptionFormats,
                             playerTrackEmsgHandler,
-                            sabrStream);
+                            stream);
         }
+        this.sabrStream = stream;
     }
 
     @Override
@@ -305,6 +308,12 @@ public class DefaultSabrChunkSource implements SabrChunkSource {
 
         RepresentationHolder representationHolder =
                 representationHolders[trackSelection.getSelectedIndex()];
+
+        // External captions contain the entire subtitle track in one sample.
+        if (representationHolder.extractorWrapper == null && previous != null) {
+            out.endOfStream = true;
+            return;
+        }
 
         if (representationHolder.extractorWrapper != null) {
             Representation selectedRepresentation = representationHolder.representation;
@@ -437,7 +446,7 @@ public class DefaultSabrChunkSource implements SabrChunkSource {
         if (!cancelable) {
             return false;
         }
-        if (isEndpointConnectionFailure(chunk, e)) {
+        if (!(chunk instanceof SingleSampleMediaChunk) && isEndpointConnectionFailure(chunk, e)) {
             if (manifest.maybeUseNextCdn(chunk.dataSpec.uri.toString())) {
                 Log.w(TAG, "Retrying SABR request on an alternate media network");
                 return true;
@@ -571,6 +580,20 @@ public class DefaultSabrChunkSource implements SabrChunkSource {
             long firstSegmentNum,
             //int maxSegmentCount,
             long seekTimeUs) {
+        Representation representation = representationHolder.representation;
+        if (representationHolder.extractorWrapper == null) {
+            DataSpec dataSpec = new DataSpec(
+                    Uri.parse(representation.baseUrl), DataSpec.HTTP_METHOD_GET, null,
+                    0, 0, C.LENGTH_UNSET, representation.getCacheKey(), 0,
+                    manifest.visitorCookie != null
+                            ? Collections.singletonMap("Cookie", manifest.visitorCookie)
+                            : Collections.emptyMap());
+            return new SingleSampleMediaChunk(
+                    dataSource, dataSpec, trackFormat, trackSelectionReason, trackSelectionData,
+                    0, representationHolder.periodDurationUs, 0, trackType, trackFormat);
+        }
+
+        SabrStream sabrStream = Assertions.checkNotNull(this.sabrStream);
         boolean isInit = nexChunkIdx == -1;
         FormatId formatId = formatSelector.getSelectedFormatId();
         int iTag = formatId != null ? formatId.getItag() : -1;
@@ -588,8 +611,6 @@ public class DefaultSabrChunkSource implements SabrChunkSource {
         //}
 
         nexChunkIdx++;
-
-        Representation representation = representationHolder.representation;
 
         //long startTimeMs = sabrStream.getSegmentStartTimeMs(trackType);
         //long durationMs = sabrStream.getSegmentDurationMs(trackType);
@@ -966,6 +987,11 @@ public class DefaultSabrChunkSource implements SabrChunkSource {
             return MimeTypes.isText(mimeType) || MimeTypes.APPLICATION_TTML.equals(mimeType);
         }
 
+        private static boolean needsExtractor(Representation representation) {
+            String containerMimeType = representation.format.containerMimeType;
+            return containerMimeType != null && !mimeTypeIsRawText(containerMimeType);
+        }
+
         private static @Nullable ChunkExtractorWrapper createExtractorWrapper(
                 int trackType,
                 Representation representation,
@@ -974,7 +1000,7 @@ public class DefaultSabrChunkSource implements SabrChunkSource {
                 TrackOutput playerEmsgTrackOutput,
                 SabrStream sabrStream) {
             String containerMimeType = representation.format.containerMimeType;
-            if (containerMimeType == null || mimeTypeIsRawText(containerMimeType)) {
+            if (!needsExtractor(representation)) {
                 return null;
             }
 

--- a/exoplayer-amzn-2.10.6/library/sabr/src/main/java/com/google/android/exoplayer2/source/sabr/manifest/SabrManifest.java
+++ b/exoplayer-amzn-2.10.6/library/sabr/src/main/java/com/google/android/exoplayer2/source/sabr/manifest/SabrManifest.java
@@ -81,6 +81,8 @@ public class SabrManifest implements FilterableManifest<SabrManifest> {
      */
     public final long minUpdatePeriodMs;
 
+    @Nullable public final String visitorCookie;
+
     private final String videoId;
     private final SabrCdnSelector cdnSelector;
     private final String videoPlaybackUstreamerConfig;
@@ -105,6 +107,29 @@ public class SabrManifest implements FilterableManifest<SabrManifest> {
             String poToken,
             String videoId,
             ClientInfo clientInfo) {
+        this(
+                availabilityStartTimeMs, durationMs, minBufferTimeMs, dynamic, minUpdatePeriodMs,
+                timeShiftBufferDepthMs, suggestedPresentationDelayMs, publishTimeMs, periods,
+                serverAbrStreamingUrl, videoPlaybackUstreamerConfig, poToken, videoId, clientInfo,
+                null);
+    }
+
+    public SabrManifest(
+            long availabilityStartTimeMs,
+            long durationMs,
+            long minBufferTimeMs,
+            boolean dynamic,
+            long minUpdatePeriodMs,
+            long timeShiftBufferDepthMs,
+            long suggestedPresentationDelayMs,
+            long publishTimeMs,
+            List<Period> periods,
+            String serverAbrStreamingUrl,
+            String videoPlaybackUstreamerConfig,
+            String poToken,
+            String videoId,
+            ClientInfo clientInfo,
+            @Nullable String visitorCookie) {
         this.availabilityStartTimeMs = availabilityStartTimeMs;
         this.durationMs = durationMs;
         this.minBufferTimeMs = minBufferTimeMs;
@@ -119,6 +144,7 @@ public class SabrManifest implements FilterableManifest<SabrManifest> {
         this.videoPlaybackUstreamerConfig = videoPlaybackUstreamerConfig;
         this.clientInfo = clientInfo;
         this.poToken = poToken;
+        this.visitorCookie = visitorCookie;
         this.sabrStreams = new HashMap<>();
         this.emptySelector = new FormatSelector("ignored", true);
     }

--- a/exoplayer-amzn-2.10.6/library/sabr/src/main/java/com/google/android/exoplayer2/source/sabr/manifest/SabrManifestParser.java
+++ b/exoplayer-amzn-2.10.6/library/sabr/src/main/java/com/google/android/exoplayer2/source/sabr/manifest/SabrManifestParser.java
@@ -90,7 +90,8 @@ public class SabrManifestParser {
                 formatInfo.getVideoPlaybackUstreamerConfig(),
                 formatInfo.getPoToken(),
                 formatInfo.getVideoId(),
-                createClientInfo(formatInfo));
+                createClientInfo(formatInfo),
+                formatInfo.getVisitorCookie());
     }
 
     private static long getDurationMs(MediaItemFormatInfo formatInfo) {

--- a/exoplayer-amzn-2.10.6/library/sabr/src/test/java/com/google/android/exoplayer2/source/sabr/DefaultSabrChunkSourceTest.java
+++ b/exoplayer-amzn-2.10.6/library/sabr/src/test/java/com/google/android/exoplayer2/source/sabr/DefaultSabrChunkSourceTest.java
@@ -1,0 +1,311 @@
+package com.google.android.exoplayer2.source.sabr;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.Format;
+import com.google.android.exoplayer2.FormatHolder;
+import com.google.android.exoplayer2.decoder.DecoderInputBuffer;
+import com.google.android.exoplayer2.source.SampleQueue;
+import com.google.android.exoplayer2.source.TrackGroup;
+import com.google.android.exoplayer2.source.chunk.BaseMediaChunkOutput;
+import com.google.android.exoplayer2.source.chunk.ChunkHolder;
+import com.google.android.exoplayer2.source.chunk.ContainerMediaChunk;
+import com.google.android.exoplayer2.source.chunk.InitializationChunk;
+import com.google.android.exoplayer2.source.chunk.MediaChunk;
+import com.google.android.exoplayer2.source.chunk.SingleSampleMediaChunk;
+import com.google.android.exoplayer2.source.sabr.manifest.AdaptationSet;
+import com.google.android.exoplayer2.source.sabr.manifest.Period;
+import com.google.android.exoplayer2.source.sabr.manifest.RangedUri;
+import com.google.android.exoplayer2.source.sabr.manifest.Representation;
+import com.google.android.exoplayer2.source.sabr.manifest.SabrManifest;
+import com.google.android.exoplayer2.source.sabr.manifest.SegmentBase.SingleSegmentBase;
+import com.google.android.exoplayer2.source.sabr.protos.videostreaming.StreamerContext.ClientInfo;
+import com.google.android.exoplayer2.trackselection.FixedTrackSelection;
+import com.google.android.exoplayer2.upstream.ByteArrayDataSource;
+import com.google.android.exoplayer2.upstream.DataSpec;
+import com.google.android.exoplayer2.upstream.DefaultAllocator;
+import com.google.android.exoplayer2.upstream.LoaderErrorThrower;
+import com.google.android.exoplayer2.util.MimeTypes;
+import com.google.android.exoplayer2.util.Util;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+@RunWith(AndroidJUnit4.class)
+@Config(sdk = 28)
+public class DefaultSabrChunkSourceTest {
+    private static final String CAPTION_URL =
+            "https://www.youtube.com/api/timedtext?v=test&lang=en&fmt=vtt";
+    private static final String SABR_URL =
+            "https://rr1---sn-primary.googlevideo.com/videoplayback?"
+                    + "mn=sn-primary%2Csn-secondary";
+    private static final long DURATION_MS = 60_000;
+    private static final byte[] CAPTIONS =
+            Util.getUtf8Bytes("WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nTest captions\n");
+
+    @Test
+    public void webvttUsesCaptionGetInsteadOfSabrContainer() {
+        assertRawTextRequest(MimeTypes.TEXT_VTT);
+    }
+
+    @Test
+    public void ttmlUsesCaptionGetInsteadOfSabrContainer() {
+        assertRawTextRequest(MimeTypes.APPLICATION_TTML);
+    }
+
+    @Test
+    public void textWithoutContainerMimeTypeUsesCaptionGet() {
+        assertRawTextRequest(null);
+    }
+
+    @Test
+    public void enablingSubtitlesMidPlaybackKeepsOriginalCueTimestamps() {
+        SabrManifest manifest = createManifest(createTextFormat(MimeTypes.TEXT_VTT), DURATION_MS);
+        DefaultSabrChunkSource source = createSource(manifest);
+        ChunkHolder out = new ChunkHolder();
+
+        source.getNextChunk(30_000_000, 30_000_000, Collections.emptyList(), out);
+
+        assertTrue(out.chunk instanceof SingleSampleMediaChunk);
+        assertEquals(0, out.chunk.startTimeUs);
+        assertEquals(DURATION_MS * 1_000, out.chunk.endTimeUs);
+    }
+
+    @Test
+    public void loadedCaptionFileEndsStreamEvenWhenDurationIsUnknown() {
+        SabrManifest manifest = createManifest(createTextFormat(MimeTypes.TEXT_VTT), C.TIME_UNSET);
+        DefaultSabrChunkSource source = createSource(manifest);
+        ChunkHolder out = new ChunkHolder();
+        source.getNextChunk(0, 0, Collections.emptyList(), out);
+        MediaChunk captionChunk = (MediaChunk) out.chunk;
+        out.clear();
+
+        source.getNextChunk(0, C.TIME_UNSET, Collections.singletonList(captionChunk), out);
+
+        assertTrue(out.endOfStream);
+        assertNull(out.chunk);
+    }
+
+    @Test
+    public void seekingWithEmptyQueueReloadsTheWholeCaptionFile() {
+        SabrManifest manifest = createManifest(createTextFormat(MimeTypes.TEXT_VTT), DURATION_MS);
+        DefaultSabrChunkSource source = createSource(manifest);
+        ChunkHolder out = new ChunkHolder();
+        source.getNextChunk(30_000_000, 30_000_000, Collections.emptyList(), out);
+        out.clear();
+
+        source.getNextChunk(5_000_000, 5_000_000, Collections.emptyList(), out);
+
+        assertTrue(out.chunk instanceof SingleSampleMediaChunk);
+        assertEquals(CAPTION_URL, out.chunk.dataSpec.uri.toString());
+        assertEquals(0, out.chunk.startTimeUs);
+        assertFalse(out.endOfStream);
+    }
+
+    @Test
+    public void loadsCaptionBytesAsOneTextSample() throws Exception {
+        Format format = createTextFormat(MimeTypes.TEXT_VTT);
+        DefaultSabrChunkSource source = createSource(createManifest(format, DURATION_MS));
+        ChunkHolder out = new ChunkHolder();
+        source.getNextChunk(0, 0, Collections.emptyList(), out);
+        assertTrue(out.chunk instanceof SingleSampleMediaChunk);
+        SingleSampleMediaChunk chunk = (SingleSampleMediaChunk) out.chunk;
+        SampleQueue sampleQueue = new SampleQueue(new DefaultAllocator(true, 1024));
+        chunk.init(new BaseMediaChunkOutput(
+                new int[] {C.TRACK_TYPE_TEXT}, new SampleQueue[] {sampleQueue}));
+
+        chunk.load();
+        source.onChunkLoadCompleted(chunk);
+
+        assertTrue(chunk.isLoadCompleted());
+        assertEquals(1, sampleQueue.getWriteIndex());
+        FormatHolder formatHolder = new FormatHolder();
+        DecoderInputBuffer buffer =
+                new DecoderInputBuffer(DecoderInputBuffer.BUFFER_REPLACEMENT_MODE_NORMAL);
+        assertEquals(C.RESULT_FORMAT_READ, sampleQueue.read(formatHolder, buffer, true, true, 0));
+        assertEquals(MimeTypes.TEXT_VTT, formatHolder.format.sampleMimeType);
+        assertEquals(C.RESULT_BUFFER_READ, sampleQueue.read(formatHolder, buffer, false, true, 0));
+        assertEquals(0, buffer.timeUs);
+        buffer.flip();
+        byte[] actual = new byte[buffer.data.remaining()];
+        buffer.data.get(actual);
+        assertArrayEquals(CAPTIONS, actual);
+        out.clear();
+        source.getNextChunk(0, chunk.endTimeUs, Collections.singletonList(chunk), out);
+        assertTrue(out.endOfStream);
+        assertNull(out.chunk);
+        sampleQueue.reset();
+    }
+
+    @Test
+    public void captionRequestIncludesVisitorCookieWithoutSabrHeaders() {
+        SabrManifest manifest = createManifest(
+                DURATION_MS, "VISITOR_INFO1_LIVE=test",
+                createAdaptationSet(createTextFormat(MimeTypes.TEXT_VTT), C.TRACK_TYPE_TEXT));
+        ChunkHolder out = new ChunkHolder();
+
+        createSource(manifest).getNextChunk(0, 0, Collections.emptyList(), out);
+
+        assertEquals(Collections.singletonMap("Cookie", "VISITOR_INFO1_LIVE=test"),
+                out.chunk.dataSpec.httpRequestHeaders);
+        assertEquals(CAPTION_URL, out.chunk.dataSpec.uri.toString());
+    }
+
+    @Test
+    public void enablingCaptionsDoesNotAdvertiseThemAsSabrFormats() {
+        Format video = createVideoFormat();
+        SabrManifest manifest = createManifest(
+                DURATION_MS, null,
+                createAdaptationSet(video, C.TRACK_TYPE_VIDEO),
+                createAdaptationSet(createTextFormat(MimeTypes.TEXT_VTT), C.TRACK_TYPE_TEXT));
+        DefaultSabrChunkSource videoSource = createSource(manifest, 0);
+        createSource(manifest, 1);
+        ChunkHolder out = new ChunkHolder();
+
+        videoSource.getNextChunk(0, 0, Collections.emptyList(), out);
+
+        assertTrue(out.chunk instanceof ContainerMediaChunk);
+        assertEquals(0, manifest.createVideoPlaybackAbrRequest(C.TRACK_TYPE_VIDEO, true)
+                .getPreferredSubtitleFormatIdsCount());
+        assertEquals(1, manifest.createVideoPlaybackAbrRequest(C.TRACK_TYPE_VIDEO, true)
+                .getPreferredVideoFormatIdsCount());
+    }
+
+    @Test
+    public void captionNetworkErrorsDoNotSwitchSabrCdn() {
+        SabrManifest manifest = spy(createManifest(createTextFormat(MimeTypes.TEXT_VTT), DURATION_MS));
+        DefaultSabrChunkSource source = createSource(manifest);
+        ChunkHolder out = new ChunkHolder();
+        source.getNextChunk(0, 0, Collections.emptyList(), out);
+
+        boolean handled = source.onChunkLoadError(
+                out.chunk, true, new IOException("caption connection failed"), C.TIME_UNSET);
+
+        assertFalse(handled);
+        verify(manifest, never()).maybeUseNextCdn(anyString());
+    }
+
+    @Test
+    public void videoStillUsesSabrContainerPost() {
+        assertSabrRequest(createVideoFormat(), C.TRACK_TYPE_VIDEO);
+    }
+
+    @Test
+    public void audioStillUsesSabrContainerPost() {
+        Format audio = Format.createAudioContainerFormat(
+                "140", null, MimeTypes.AUDIO_MP4, MimeTypes.AUDIO_AAC, null, null,
+                128_000, 2, 44_100, null, 0, 0, "en");
+        assertSabrRequest(audio, C.TRACK_TYPE_AUDIO);
+    }
+
+    @Test
+    public void videoInitializationStillUsesSabrPost() {
+        Representation representation = Representation.newInstance(
+                createVideoFormat(), SABR_URL,
+                new SingleSegmentBase(new RangedUri(null, 0, 100), 1, 0, 0, 0));
+        SabrManifest manifest = createManifest(
+                DURATION_MS, null,
+                new AdaptationSet(0, C.TRACK_TYPE_VIDEO, Collections.singletonList(representation)));
+        ChunkHolder out = new ChunkHolder();
+
+        createSource(manifest).getNextChunk(0, 0, Collections.emptyList(), out);
+
+        assertTrue(out.chunk instanceof InitializationChunk);
+        assertEquals(DataSpec.HTTP_METHOD_POST, out.chunk.dataSpec.httpMethod);
+        assertEquals(SABR_URL + "&rn=0", out.chunk.dataSpec.uri.toString());
+    }
+
+    private static void assertSabrRequest(Format format, int trackType) {
+        SabrManifest manifest = createManifest(
+                DURATION_MS, "VISITOR_INFO1_LIVE=test", createAdaptationSet(format, trackType));
+        ChunkHolder out = new ChunkHolder();
+
+        createSource(manifest).getNextChunk(0, 0, Collections.emptyList(), out);
+
+        assertTrue(out.chunk instanceof ContainerMediaChunk);
+        assertEquals(DataSpec.HTTP_METHOD_POST, out.chunk.dataSpec.httpMethod);
+        assertEquals(SABR_URL + "&rn=0", out.chunk.dataSpec.uri.toString());
+        assertEquals("application/x-protobuf", out.chunk.dataSpec.httpRequestHeaders.get("Content-Type"));
+        assertFalse(out.chunk.dataSpec.httpRequestHeaders.containsKey("Cookie"));
+        assertTrue(out.chunk.dataSpec.httpBody.length > 0);
+    }
+
+    private static void assertRawTextRequest(String containerMimeType) {
+        SabrManifest manifest = createManifest(createTextFormat(containerMimeType), DURATION_MS);
+        DefaultSabrChunkSource source = createSource(manifest);
+        ChunkHolder out = new ChunkHolder();
+
+        source.getNextChunk(0, 0, Collections.emptyList(), out);
+
+        assertTrue(out.chunk instanceof SingleSampleMediaChunk);
+        assertEquals(CAPTION_URL, out.chunk.dataSpec.uri.toString());
+        assertEquals(DataSpec.HTTP_METHOD_GET, out.chunk.dataSpec.httpMethod);
+        assertNull(out.chunk.dataSpec.httpBody);
+        assertTrue(out.chunk.dataSpec.httpRequestHeaders.isEmpty());
+        assertEquals(-1, manifest.getSabrRequestNumber());
+    }
+
+    private static Format createTextFormat(String containerMimeType) {
+        return Format.createTextContainerFormat(
+                "en", null, containerMimeType,
+                containerMimeType == null ? MimeTypes.TEXT_VTT : containerMimeType,
+                null, Format.NO_VALUE, 0, C.ROLE_FLAG_SUBTITLE, "en");
+    }
+
+    private static SabrManifest createManifest(Format format, long durationMs) {
+        return createManifest(durationMs, null, createAdaptationSet(format, C.TRACK_TYPE_TEXT));
+    }
+
+    private static Format createVideoFormat() {
+        return Format.createVideoContainerFormat(
+                "137", null, MimeTypes.VIDEO_MP4, MimeTypes.VIDEO_H264, null, null,
+                1_000_000, 1920, 1080, 30, null, 0, 0);
+    }
+
+    private static AdaptationSet createAdaptationSet(Format format, int trackType) {
+        Representation representation =
+                Representation.newInstance(format,
+                        trackType == C.TRACK_TYPE_TEXT ? CAPTION_URL : SABR_URL,
+                        new SingleSegmentBase());
+        return new AdaptationSet(trackType, trackType, Collections.singletonList(representation));
+    }
+
+    private static SabrManifest createManifest(
+            long durationMs, String visitorCookie, AdaptationSet... adaptationSets) {
+        Period period = new Period("test", 0, Arrays.asList(adaptationSets));
+        return new SabrManifest(
+                C.TIME_UNSET, durationMs, 1_500, false,
+                C.TIME_UNSET, C.TIME_UNSET, C.TIME_UNSET, C.TIME_UNSET,
+                Collections.singletonList(period), SABR_URL, "", null, "test",
+                ClientInfo.getDefaultInstance(), visitorCookie);
+    }
+
+    private static DefaultSabrChunkSource createSource(SabrManifest manifest) {
+        return createSource(manifest, 0);
+    }
+
+    private static DefaultSabrChunkSource createSource(SabrManifest manifest, int adaptationSetIndex) {
+        AdaptationSet adaptationSet = manifest.getPeriod(0).adaptationSets.get(adaptationSetIndex);
+        Format format = adaptationSet.representations.get(0).format;
+        return new DefaultSabrChunkSource(
+                new LoaderErrorThrower.Dummy(), manifest, 0, new int[] {adaptationSetIndex},
+                new FixedTrackSelection(new TrackGroup(format), 0), adaptationSet.type,
+                new ByteArrayDataSource(CAPTIONS), 0, 1, false, Collections.emptyList(), null);
+    }
+}

--- a/exoplayer-amzn-2.10.6/library/sabr/src/test/java/com/google/android/exoplayer2/source/sabr/manifest/SabrManifestParserTest.java
+++ b/exoplayer-amzn-2.10.6/library/sabr/src/test/java/com/google/android/exoplayer2/source/sabr/manifest/SabrManifestParserTest.java
@@ -1,0 +1,56 @@
+package com.google.android.exoplayer2.source.sabr.manifest;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.util.MimeTypes;
+import com.liskovsoft.mediaserviceinterfaces.data.MediaItemFormatInfo;
+import com.liskovsoft.mediaserviceinterfaces.data.MediaSubtitle;
+
+import java.util.Collections;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+@RunWith(AndroidJUnit4.class)
+@Config(sdk = 28)
+public class SabrManifestParserTest {
+    @Test
+    public void preservesVisitorCookieAndExternalCaptionUrl() {
+        MediaItemFormatInfo formatInfo = mock(MediaItemFormatInfo.class);
+        MediaItemFormatInfo.ClientInfo clientInfo = mock(MediaItemFormatInfo.ClientInfo.class);
+        when(clientInfo.getClientName()).thenReturn("WEB");
+        when(clientInfo.getClientVersion()).thenReturn("test");
+        when(clientInfo.getOsName()).thenReturn("");
+        when(clientInfo.getOsVersion()).thenReturn("");
+        when(formatInfo.getClientInfo()).thenReturn(clientInfo);
+        when(formatInfo.getLengthSeconds()).thenReturn("60");
+        when(formatInfo.getVideoId()).thenReturn("test");
+        when(formatInfo.getServerAbrStreamingUrl())
+                .thenReturn("https://media.example/videoplayback");
+        when(formatInfo.getAdaptiveFormats()).thenReturn(Collections.emptyList());
+        when(formatInfo.getVisitorCookie()).thenReturn("VISITOR_INFO1_LIVE=test");
+        MediaSubtitle subtitle = mock(MediaSubtitle.class);
+        when(subtitle.getMimeType()).thenReturn(MimeTypes.TEXT_VTT);
+        when(subtitle.getLanguageCode()).thenReturn("en");
+        when(subtitle.getVssId()).thenReturn("en");
+        when(subtitle.getBaseUrl()).thenReturn("https://www.youtube.com/api/timedtext?lang=en");
+        when(formatInfo.getSubtitles()).thenReturn(Collections.singletonList(subtitle));
+
+        SabrManifest manifest = new SabrManifestParser().parse(formatInfo);
+
+        assertEquals("VISITOR_INFO1_LIVE=test", manifest.visitorCookie);
+        assertEquals(60_000, manifest.durationMs);
+        AdaptationSet captions = manifest.getPeriod(0).adaptationSets.get(0);
+        assertEquals(C.TRACK_TYPE_TEXT, captions.type);
+        Representation representation = captions.representations.get(0);
+        assertEquals(subtitle.getBaseUrl(), representation.baseUrl);
+        assertEquals(MimeTypes.TEXT_VTT, representation.format.containerMimeType);
+        assertEquals(1, representation.getIndex().getSegmentCount(60_000_000));
+    }
+}


### PR DESCRIPTION
## Purpose

Fixes #6180.

This change corrects a subtitle loading failure during SABR playback.

## Cause

YouTube supplies these subtitles as separate text files.
The unmodified SABR loader sends these files to `ContainerMediaChunk`.
Text representations have no `ChunkExtractorWrapper`.
The loader calls `init()` on the null extractor and causes `Unexpected NullPointerException`.
Automatic retries can select DASH, which can make the failure difficult to reproduce.

## Changes

* Load external subtitle files with HTTP GET and `SingleSampleMediaChunk`.
* Include the visitor cookie in subtitle requests when available.
* Keep the original subtitle timestamps during playback and seek operations.
* End the subtitle stream after one file, including when the video duration is unknown.
* Keep subtitle selections separate from SABR requests for audio and video.
* Do not change the SABR media network when a subtitle request fails.

Audio and video keep the SABR request path.
The change also adds regression tests and updates the module documentation.

## Verification

All 20 SABR tests pass with JDK 11.
The change adds 14 regression tests.
Six of these tests fail with the unmodified code and pass with this change.
The tests cover WebVTT, TTML, subtitle data, timestamps, cookies, stream completion, network errors, and audio and video requests.

Run these commands from the repository root:

```sh
export JAVA_HOME=/path/to/jdk-11
bash ./gradlew :exoplayer-library-sabr:testStstableDebugUnitTest :smarttubetv:assembleStstableDebug
```

Manual checks used an Android TV 14 ARM64 emulator.
Subtitles appeared during playback, after an app restart, and after forward and backward seeks.
The fixed build produced no matching subtitle exception.
The checks do not cover physical Fire TV hardware.

## Reproduction

Use the [example video from the issue](https://www.youtube.com/watch?v=F4U-HfdTGG8).

1. Install the unmodified build from commit `a6d8d8153`.
2. Open the example video.
3. Select English under **Subtitles (autogenerated)**.
4. Close the app.
5. Start the app with the same video and subtitles enabled.
6. Check the application log for `Unexpected NullPointerException`.
7. Install the fixed build without deleting the app data.
8. Repeat steps 2 through 5.
9. Make sure the subtitles appear and playback continues.

The failure requires SABR playback.
Check the application log for `Loading video in sabr format...`.

## Screenshots

Both images show video `F4U-HfdTGG8` on the same emulator with autogenerated English subtitles selected.
The screenshots are on a separate branch in the fork, outside the code diff.

### Before the change

The unmodified build starts loading again after the subtitle exception.
The application log records `Unexpected NullPointerException` at `ContainerMediaChunk.java:123`.

![Before: the same video returns to loading with subtitles selected](https://raw.githubusercontent.com/yasoob/SmartTube/03af6b104c87329e7bbaa39a97b60659612b3bcb/smarttube-6180-before.png)

### After the change

The fixed build plays the same video and displays the subtitles after an app restart.

![After: the same video plays with visible English subtitles](https://raw.githubusercontent.com/yasoob/SmartTube/03af6b104c87329e7bbaa39a97b60659612b3bcb/smarttube-6180-after.png)
